### PR TITLE
feat(pwa): make site a Progressive Web App

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,18 @@
 
 每次修改后，运行 `npm run lint` 确保代码格式符合规范。如果格式检查失败，修复代码格式后再提交。
 
+## Service Worker (`sw.js`) 维护
+
+修改 `sw.js` 时必须遵守以下要求，否则会导致用户 PWA 缓存出现不一致或更新失败。
+
+- **bump `VERSION`**：只要修改 `sw.js` 的逻辑或 `PRECACHE_URLS` 列表，必须把顶部的 `VERSION` 常量改成新值（例如 `2026-05-24-1`）。`CACHE_NAME` 由 `VERSION` 拼接而来，新 cache 名才能让 `activate` 阶段删掉旧 cache。
+- **同步 `PRECACHE_URLS`**：当新增、改名、删除"全站共享的根级资源"（如 `js/common.js`、`css/index.css`、`images/pwa-icon.svg`、`manifest.webmanifest`）时，必须同步更新 `PRECACHE_URLS`。每个游戏自己的 `game.css` / `game.js` **不要**加入预缓存，它们由运行时 stale-while-revalidate 自动管理。
+- **保留缓存策略边界**：HTML / 导航请求走 network-first，同源静态资源走 stale-while-revalidate；跨域请求**默认直通不缓存**，只有 `CROSS_ORIGIN_PRECACHE` 白名单里的 CDN 脚本/样式才会预缓存并走 SWR。改动 `fetch` handler 时不要破坏这四条分流。
+- **维护跨域白名单**：当 HTML 中新增 / 改动 / 删除 CDN 引用（jsdelivr 上的 jQuery、slotmachine 等）时，必须同步更新 `CROSS_ORIGIN_PRECACHE`。**绝不要**把分析统计类（如百度统计、Google Analytics）加入白名单——统计请求本来就该有就有、没就没。
+- **保留 kill switch**：`?nosw=1` 必须仍能注销所有 SW 并清空 cache（实现在 `js/common.js` 里）。改 SW 注册逻辑时不要破坏它。
+- **不要拦截 `sw.js` 自身**：fetch handler 必须保留 `if (url.pathname.endsWith("/sw.js")) return;`，否则浏览器拿不到新版 sw.js，更新机制会卡住。
+- **预缓存路径用相对形式**：`PRECACHE_URLS` 全部以 `./` 开头，确保 GitHub Pages 的 `/childhood/` 子路径部署也能正确解析。
+
 ## Git 提交
 
 commit message 使用英文。

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://sonarcloud.io/dashboard?id=jiangxincode_childhood"><img src="https://sonarcloud.io/api/project_badges/measure?project=jiangxincode_childhood&metric=alert_status" alt="Quality Gate Status"></a>
 </p>
 
-一个纯前端经典游戏合集，收录了 **23 款**童年桌游与卡牌游戏，零框架、零构建，开箱即玩。
+一个纯前端经典游戏合集，收录了 **23 款**童年桌游与卡牌游戏，开箱即玩。
 
 **[在线体验](https://jiangxincode.github.io/childhood/)**
 

--- a/README.md
+++ b/README.md
@@ -107,12 +107,9 @@ cd childhood
 
 # 安装依赖
 npm install
-
-# 直接用浏览器打开即可
-open index.html        # macOS
-start index.html       # Windows
-xdg-open index.html    # Linux
 ```
+
+直接用浏览器打开`index.html`即可，或者`npx serve`后访问<http://localhost:3000>
 
 ## 运行测试
 

--- a/apps/board-game/checkers/index.html
+++ b/apps/board-game/checkers/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩国际跳棋，经典棋盘游戏，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="国际跳棋,跳棋,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/checkers/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/chinese-army-chess/index.html
+++ b/apps/board-game/chinese-army-chess/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩军棋明棋，经典策略棋盘游戏，军师旅团营连排工兵地雷军旗，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="军棋,明棋,陆战棋,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/chinese-army-chess/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/chinese-checkers/index.html
+++ b/apps/board-game/chinese-checkers/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩中国跳棋，经典棋盘游戏，支持多人对战，无需下载，即开即玩。">
   <meta name="keywords" content="中国跳棋,跳棋,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/chinese-checkers/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/chinese-chess/index.html
+++ b/apps/board-game/chinese-chess/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩中国象棋，经典国粹棋盘游戏，车马炮将士象兵，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="中国象棋,象棋,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/chinese-chess/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/go/index.html
+++ b/apps/board-game/go/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩围棋，经典策略棋盘游戏，黑白博弈，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="围棋,Go,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/go/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/gomoku/index.html
+++ b/apps/board-game/gomoku/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩五子棋，经典策略棋盘游戏，先连成五子者获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="五子棋,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/gomoku/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/international-chess/index.html
+++ b/apps/board-game/international-chess/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩国际象棋，经典策略棋盘游戏，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="国际象棋,Chess,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/international-chess/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/reversi/index.html
+++ b/apps/board-game/reversi/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩黑白棋，又称翻转棋、奥赛罗棋，经典策略棋盘游戏，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="黑白棋,翻转棋,奥赛罗,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/reversi/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/board-game/tic-tac-toe/index.html
+++ b/apps/board-game/tic-tac-toe/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩井字棋，经典三子棋游戏，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="井字棋,三子棋,OOXX,棋盘游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/board-game/tic-tac-toe/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/card-game/animal-chess/index.html
+++ b/apps/card-game/animal-chess/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩兽棋，经典童年动物棋牌对战游戏，象吃狮、狮吃虎、虎吃豹、豹吃狼、狼吃狗、狗吃猫、猫吃鼠、鼠吃象，无需下载，即开即玩。">
   <meta name="keywords" content="兽棋,动物棋,童年游戏,卡牌游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/card-game/animal-chess/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/card-game/cat-and-mouse/index.html
+++ b/apps/card-game/cat-and-mouse/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩猫捉老鼠，经典童年卡牌游戏，猫鼠棋牌对战，无需下载，即开即玩。">
   <meta name="keywords" content="猫捉老鼠,童年游戏,卡牌游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/card-game/cat-and-mouse/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/card-game/chinese-army-chess/index.html
+++ b/apps/card-game/chinese-army-chess/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩军师旅团营翻翻棋，经典童年卡牌军棋游戏，军师旅团营连排工兵地雷军旗，无需下载，即开即玩。">
   <meta name="keywords" content="军师旅团营,翻翻棋,童年游戏,卡牌游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/card-game/chinese-army-chess/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/card-game/dragon-tiger-fight/index.html
+++ b/apps/card-game/dragon-tiger-fight/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩龙虎斗，经典童年卡牌对战游戏，龙争虎斗，无需下载，即开即玩。">
   <meta name="keywords" content="龙虎斗,童年游戏,卡牌游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/card-game/dragon-tiger-fight/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/card-game/knife-kills-chicken/index.html
+++ b/apps/card-game/knife-kills-chicken/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩刀杀鸡，经典童年卡牌游戏，刀杀鸡、鸡吃虫、虫蛀棒、棒打老虎、虎吃鸡，无需下载，即开即玩。">
   <meta name="keywords" content="刀杀鸡,童年游戏,卡牌游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/card-game/knife-kills-chicken/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/card-game/little-emperor/index.html
+++ b/apps/card-game/little-emperor/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩小皇帝，经典童年卡牌游戏，家庭成员循环克制对战，无需下载，即开即玩。">
   <meta name="keywords" content="小皇帝,童年游戏,卡牌游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/card-game/little-emperor/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/bai-si-long/index.html
+++ b/apps/childhood-board-game/bai-si-long/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩摆四龙，经典童年棋盘游戏，4x4 交点棋盘双方各执 4 子在上下两行交叉布阵，每回合沿横竖斜方向走一步，最先将己方 4 子摆成一条直线即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="摆四龙,童年棋盘,四子连线,交点棋盘,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/bai-si-long/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/bie-mao-keng/index.html
+++ b/apps/childhood-board-game/bie-mao-keng/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩憋茅坑，经典童年棋盘游戏，方形棋盘双方各执两子沿连线移动，将对方逼入死角无路可走即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="憋茅坑,童年棋盘,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/bie-mao-keng/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/lang-chi-yang/index.html
+++ b/apps/childhood-board-game/lang-chi-yang/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩狼吃羊，经典童年棋盘游戏，4x5棋盘羊群对抗狼群，狼可隔空跳吃羊，羊群围困狼群即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="狼吃羊,童年棋盘,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/lang-chi-yang/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/ma-yi-ban-jia/index.html
+++ b/apps/childhood-board-game/ma-yi-ban-jia/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩蚂蚁搬家，经典童年棋盘游戏，9x9 棋盘双方各执 4 子在中央纵线对峙，棋盘正中天元不可越过，每回合上下左右走一步或跳过一颗棋子，先把己方 4 子全部搬到对方家即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="蚂蚁搬家,童年棋盘,跳子,天元,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/ma-yi-ban-jia/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/si-bu-ding/index.html
+++ b/apps/childhood-board-game/si-bu-ding/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩四步钉（也叫四子棋），经典童年棋盘游戏，4x4 交点棋盘双方各执 4 子在上下两行对峙，每回合横竖走一步，两子夹对方一子即可吃子，先吃掉对方 3 子即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="四步钉,四子棋,童年棋盘,夹子吃子,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/si-bu-ding/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/xiao-mao-diao-yu/index.html
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩小猫钓鱼（也叫鸡毛蒜皮），经典童年棋盘游戏，十字形棋盘双方各执四子，每回合走一步或按"小猫钓鱼"咒语走三步吃子，吃光对方或封锁对方即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="小猫钓鱼,鸡毛蒜皮,童年棋盘,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/xiao-mao-diao-yu/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css?v=2">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/index.html
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="在线免费玩钻牛角尖（牛角棋），经典童年不对称棋盘游戏，11 个节点的牛角形棋盘，追兵两子从牛角根追、逃兵一子从牛角尖逃，沿连线移动一步，逃兵到达牛角根或追兵把逃兵困进牛角尖即获胜，支持双人对战和人机对战，无需下载，即开即玩。">
   <meta name="keywords" content="钻牛角尖,牛角棋,童年棋盘,不对称棋盘,棋盘游戏,策略游戏,在线游戏,免费游戏">
   <link rel="canonical" href="https://jiangxincode.github.io/childhood/apps/childhood-board-game/zuan-niu-jiao-jian/index.html">
+  <script src="../../../js/base-fix.js"></script>
   <link rel="stylesheet" href="game.css">
   <script src="../../../js/baidu-analytics.js"></script>
   <script src="../../../js/common.js"></script>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ export default [
         prompt: "readonly",
         fetch: "readonly",
         URL: "readonly",
+        URLSearchParams: "readonly",
+        caches: "readonly",
         HTMLElement: "readonly",
         AudioContext: "readonly",
         webkitAudioContext: "readonly",
@@ -75,6 +77,23 @@ export default [
     files: ["**/*.test.js"],
     rules: {
       "no-var": "off",
+    },
+  },
+  {
+    // Service worker context: different globals from regular browser scripts.
+    files: ["sw.js", "**/sw.js"],
+    languageOptions: {
+      globals: {
+        self: "readonly",
+        Request: "readonly",
+        Response: "readonly",
+        Headers: "readonly",
+        caches: "readonly",
+        clients: "readonly",
+        fetch: "readonly",
+        URL: "readonly",
+        console: "readonly",
+      },
     },
   },
   {

--- a/images/pwa-icon-maskable.svg
+++ b/images/pwa-icon-maskable.svg
@@ -1,0 +1,34 @@
+<!-- Maskable PWA icon. Keep all important visuals inside the central 80% safe zone. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="pwaBgMask" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#E74C3C"/>
+      <stop offset="100%" style="stop-color:#C0392B"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Full-bleed background so masks of any shape stay on-brand -->
+  <rect width="512" height="512" fill="url(#pwaBgMask)"/>
+
+  <!-- All foreground glyphs scaled into the central safe zone (51..461) -->
+  <g transform="translate(102, 102) scale(0.6)">
+    <!-- 3x3 board grid -->
+    <g opacity="0.3" stroke="#FFF" stroke-width="10" stroke-linecap="round">
+      <line x1="200" y1="120" x2="200" y2="392"/>
+      <line x1="312" y1="120" x2="312" y2="392"/>
+      <line x1="120" y1="200" x2="392" y2="200"/>
+      <line x1="120" y1="312" x2="392" y2="312"/>
+    </g>
+
+    <!-- Center game pawn -->
+    <g transform="translate(256, 220)">
+      <circle cx="0" cy="0" r="40" fill="#F7C948"/>
+      <path d="M-32,28 Q-32,72 0,86 Q32,72 32,28 Z" fill="#F7C948"/>
+      <ellipse cx="0" cy="96" rx="48" ry="14" fill="#F7C948" opacity="0.6"/>
+    </g>
+
+    <!-- Star -->
+    <polygon points="408,96 419,124 449,124 425,143 433,170 408,153 383,170 391,143 367,124 397,124"
+             fill="#F7C948" opacity="0.85"/>
+  </g>
+</svg>

--- a/images/pwa-icon.svg
+++ b/images/pwa-icon.svg
@@ -1,0 +1,34 @@
+<!-- Square PWA icon (purpose: any). Visual content fills the canvas. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="pwaBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#E74C3C"/>
+      <stop offset="100%" style="stop-color:#C0392B"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Rounded square background -->
+  <rect width="512" height="512" rx="96" fill="url(#pwaBg)"/>
+
+  <!-- 3x3 board grid -->
+  <g opacity="0.3" stroke="#FFF" stroke-width="6" stroke-linecap="round">
+    <line x1="200" y1="120" x2="200" y2="392"/>
+    <line x1="312" y1="120" x2="312" y2="392"/>
+    <line x1="120" y1="200" x2="392" y2="200"/>
+    <line x1="120" y1="312" x2="392" y2="312"/>
+  </g>
+
+  <!-- Center game pawn -->
+  <g transform="translate(256, 220)">
+    <circle cx="0" cy="0" r="40" fill="#F7C948"/>
+    <path d="M-32,28 Q-32,72 0,86 Q32,72 32,28 Z" fill="#F7C948"/>
+    <ellipse cx="0" cy="96" rx="48" ry="14" fill="#F7C948" opacity="0.6"/>
+  </g>
+
+  <!-- Star -->
+  <polygon points="408,96 419,124 449,124 425,143 433,170 408,153 383,170 391,143 367,124 397,124"
+           fill="#F7C948" opacity="0.85"/>
+
+  <!-- Small dot -->
+  <circle cx="116" cy="404" r="14" fill="#F7C948" opacity="0.4"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,17 @@
 <meta http-equiv="cache-control" content="no-cache">
 <meta http-equiv="expires" content="0">
 
+<!-- PWA -->
+<link rel="manifest" href="manifest.webmanifest">
+<meta name="theme-color" content="#E74C3C">
+<meta name="application-name" content="童年游戏合集">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<meta name="apple-mobile-web-app-title" content="童年游戏">
+<link rel="icon" type="image/svg+xml" href="images/pwa-icon.svg">
+<link rel="apple-touch-icon" href="images/pwa-icon.svg">
+
 <link rel="stylesheet" type="text/css" href="css/normalize.css" />
 <link rel="stylesheet" href="css/jquery-yys-slider.css">
 <link rel="stylesheet" href="css/index.css">

--- a/js/base-fix.js
+++ b/js/base-fix.js
@@ -19,7 +19,7 @@
  * preload scanner kicks in.
  */
 (function () {
-  var p = location.pathname;
+  const p = location.pathname;
   if (!p.endsWith("/") && !/\.html?$/i.test(p)) {
     document.write('<base href="' + p.split("/").pop() + '/">');
   }

--- a/js/base-fix.js
+++ b/js/base-fix.js
@@ -1,0 +1,26 @@
+/**
+ * Auto <base> fix.
+ *
+ * Some static servers (e.g. Vercel `serve` with cleanUrls enabled) rewrite
+ *   /foo/index.html -> 301 -> /foo/index -> 301 -> /foo
+ * Once the browser lands on the no-trailing-slash form, every relative URL in
+ * the page resolves one directory up, breaking CSS / JS / images.
+ *
+ * This shim runs *before* any <link>/<script> in the page. It detects the
+ * unsafe URL shape (no trailing slash, no .html/.htm suffix) and injects a
+ * <base href="<lastSegment>/"> so relative paths keep pointing at this
+ * directory.
+ *
+ * No-op for file:// URLs and any URL that already ends with "/" or ".html",
+ * so direct file access and well-formed URLs are unaffected.
+ *
+ * Must be loaded synchronously, NOT with `defer` or `async`, and as the very
+ * first <script> in <head> so the injected <base> is in the DOM before the
+ * preload scanner kicks in.
+ */
+(function () {
+  var p = location.pathname;
+  if (!p.endsWith("/") && !/\.html?$/i.test(p)) {
+    document.write('<base href="' + p.split("/").pop() + '/">');
+  }
+})();

--- a/js/common.js
+++ b/js/common.js
@@ -107,10 +107,18 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Back to home button (subpages only, paths containing /apps/)
   if (window.location.pathname.indexOf("/apps/") !== -1) {
-    // Calculate relative path to root (e.g. apps/card-game/xxx/index.html needs ../../../)
-    const depth = window.location.pathname.replace(/\/[^/]*$/, "").split("/apps/")[1];
-    const levels = depth ? depth.split("/").length + 1 : 1;
-    const prefix = new Array(levels + 1).join("../");
+    // Calculate relative path to root.
+    // Pathname forms we need to support:
+    //   .../apps/card-game/chinese-army-chess/index.html  (file://, GitHub Pages)
+    //   .../apps/card-game/chinese-army-chess/             (with trailing slash)
+    //   .../apps/card-game/chinese-army-chess              (serve cleanUrls strips it)
+    // Real depth = number of directory segments after "/apps/" (skip the
+    // index.html part and the empty tail caused by trailing slash) + 1 for
+    // jumping out of the "apps" directory itself.
+    const tail = window.location.pathname.split("/apps/")[1] || "";
+    const dirs = tail.split("/").filter((s) => s && !/\.html?$/i.test(s));
+    const levels = dirs.length + 1;
+    const prefix = "../".repeat(levels);
 
     const back = document.createElement("a");
     back.className = "back-home";

--- a/js/common.js
+++ b/js/common.js
@@ -65,6 +65,46 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  // PWA: register service worker (with ?nosw=1 kill switch).
+  // Uses a root-relative URL so the SW scope always covers the whole site,
+  // regardless of which page registers it. Falls back silently when the
+  // page is opened over file:// or in a browser without SW support, so
+  // direct browser access is never blocked.
+  if ("serviceWorker" in navigator) {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("nosw")) {
+      // Kill switch: tear down every SW + cache for this origin.
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => regs.forEach((r) => r.unregister()))
+        .catch(() => {});
+      if (window.caches && caches.keys) {
+        caches
+          .keys()
+          .then((keys) => keys.forEach((k) => caches.delete(k)))
+          .catch(() => {});
+      }
+    } else if (
+      window.location.protocol === "https:" ||
+      window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1"
+    ) {
+      // Resolve sw.js relative to the site root so any subpage works.
+      // location.pathname examples:
+      //   /childhood/                -> base "/childhood/"
+      //   /childhood/apps/x/y/index.html -> base "/childhood/"
+      const path = window.location.pathname;
+      const appsIdx = path.indexOf("/apps/");
+      const base = appsIdx !== -1 ? path.slice(0, appsIdx + 1) : path.replace(/[^/]*$/, "");
+      const swUrl = base + "sw.js";
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register(swUrl, { scope: base }).catch(() => {
+          // Silent: SW registration failure must not break the page.
+        });
+      });
+    }
+  }
+
   // Back to home button (subpages only, paths containing /apps/)
   if (window.location.pathname.indexOf("/apps/") !== -1) {
     // Calculate relative path to root (e.g. apps/card-game/xxx/index.html needs ../../../)

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,36 @@
+{
+  "name": "童年游戏合集",
+  "short_name": "童年游戏",
+  "description": "免费在线玩刀杀鸡、龙虎斗、五子棋、中国象棋、围棋、跳棋等经典童年棋牌游戏，无需下载，即开即玩。",
+  "lang": "zh-CN",
+  "dir": "ltr",
+  "start_url": "./index.html",
+  "scope": "./",
+  "id": "/childhood/",
+  "display": "standalone",
+  "display_override": ["standalone", "minimal-ui", "browser"],
+  "orientation": "any",
+  "background_color": "#1A5276",
+  "theme_color": "#E74C3C",
+  "categories": ["games", "entertainment"],
+  "icons": [
+    {
+      "src": "./images/pwa-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "./images/pwa-icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    },
+    {
+      "src": "./images/logo-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "monochrome"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -31,6 +31,7 @@ const PRECACHE_URLS = [
   "./css/index.css",
   "./js/common.js",
   "./js/jquery-yys-slider.js",
+  "./js/base-fix.js",
   "./images/logo.svg",
   "./images/logo-icon.svg",
   "./images/pwa-icon.svg",

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,10 @@
  *   - HTML / navigation requests : network-first, fall back to cache, then offline shell.
  *   - Same-origin static assets  : stale-while-revalidate (cache hit served immediately,
  *                                  cache refreshed in the background).
- *   - Cross-origin requests      : passed through to the network, never cached.
+ *   - Cross-origin allowlist     : same SWR behaviour, but only for the few CDN
+ *                                  scripts/styles the app actually needs to run
+ *                                  (jQuery, slotmachine). Listed in CROSS_ORIGIN_PRECACHE.
+ *   - Other cross-origin         : passed through, never cached (e.g. analytics).
  *
  * Versioning
  *   Bump VERSION below to invalidate every previous cache. The `activate` handler
@@ -17,7 +20,7 @@
  */
 
 // Bump this string to ship a new cache. Keep it short and unique.
-const VERSION = "2026-05-23-1";
+const VERSION = "2026-05-23-2";
 const CACHE_NAME = `childhood-${VERSION}`;
 
 // App shell precache: only the global resources used by every page.
@@ -38,19 +41,38 @@ const PRECACHE_URLS = [
   "./images/pwa-icon-maskable.svg",
 ];
 
+// Cross-origin scripts/styles required for the app to actually run offline.
+// Listed by full URL so the same constant doubles as the runtime allowlist.
+// Anything not in this set keeps the original "skip and let the network
+// handle it" behaviour (e.g. analytics beacons must never be cached).
+const CROSS_ORIGIN_PRECACHE = [
+  "https://cdn.jsdelivr.net/npm/jquery@4.0.0/dist/jquery.min.js",
+  "https://cdn.jsdelivr.net/npm/jquery-slotmachine@6.0.0/dist/slotmachine.min.js",
+  "https://cdn.jsdelivr.net/npm/jquery-slotmachine@6.0.0/dist/slotmachine.css",
+];
+const CROSS_ORIGIN_ALLOWLIST = new Set(CROSS_ORIGIN_PRECACHE);
+
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) =>
+    caches.open(CACHE_NAME).then((cache) => {
+      // Same-origin requests: use { cache: "reload" } to dodge the HTTP cache.
+      const sameOrigin = PRECACHE_URLS.map((u) => new Request(u, { cache: "reload" }));
+      // Cross-origin requests: force CORS mode so we get a real, readable
+      // response (jsdelivr already serves CORS headers, and the <script>
+      // tags use crossorigin="anonymous"). Without this we would only get
+      // opaque responses, which work but inflate the cache quota.
+      const crossOrigin = CROSS_ORIGIN_PRECACHE.map(
+        (u) => new Request(u, { mode: "cors", credentials: "omit" })
+      );
+      const all = [...sameOrigin, ...crossOrigin];
       // Use Promise.all + per-item catch so one missing asset
       // does not abort the whole install step.
-      Promise.all(
-        PRECACHE_URLS.map((url) =>
-          cache
-            .add(new Request(url, { cache: "reload" }))
-            .catch((err) => console.warn("[SW] precache failed:", url, err))
+      return Promise.all(
+        all.map((req) =>
+          cache.add(req).catch((err) => console.warn("[SW] precache failed:", req.url, err))
         )
-      )
-    )
+      );
+    })
   );
 });
 
@@ -86,14 +108,19 @@ self.addEventListener("fetch", (event) => {
   // Only intercept GET; let POST / PUT / etc. go straight to the network.
   if (req.method !== "GET") return;
 
-  // Parse URL safely, then skip cross-origin (CDN, analytics, ...).
+  // Parse URL safely. Skip cross-origin requests *unless* they are on the
+  // explicit allowlist (vendored CDN scripts that the app needs to run).
+  // Everything else cross-origin (analytics, GitHub avatars, ...) keeps
+  // its original behaviour: the SW does not touch it.
   let url;
   try {
     url = new URL(req.url);
   } catch {
     return;
   }
-  if (url.origin !== self.location.origin) return;
+  if (url.origin !== self.location.origin && !CROSS_ORIGIN_ALLOWLIST.has(req.url)) {
+    return;
+  }
 
   // Never intercept the SW file itself.
   if (url.pathname.endsWith("/sw.js")) return;
@@ -140,13 +167,16 @@ async function networkFirst(req) {
 /**
  * Stale-while-revalidate: serve from cache immediately, refresh the cache in
  * the background. Suitable for CSS / JS / images / fonts.
+ *
+ * Caches both same-origin (response.type === "basic") and CORS responses
+ * (response.type === "cors") so allowlisted CDN assets survive offline.
  */
 async function staleWhileRevalidate(req) {
   const cache = await caches.open(CACHE_NAME);
   const cached = await cache.match(req);
   const networkPromise = fetch(req)
     .then((res) => {
-      if (res && res.status === 200 && res.type === "basic") {
+      if (res && res.status === 200 && (res.type === "basic" || res.type === "cors")) {
         cache.put(req, res.clone()).catch(() => {});
       }
       return res;

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,155 @@
+/**
+ * Service Worker for 童年游戏合集.
+ *
+ * Caching strategy
+ *   - HTML / navigation requests : network-first, fall back to cache, then offline shell.
+ *   - Same-origin static assets  : stale-while-revalidate (cache hit served immediately,
+ *                                  cache refreshed in the background).
+ *   - Cross-origin requests      : passed through to the network, never cached.
+ *
+ * Versioning
+ *   Bump VERSION below to invalidate every previous cache. The `activate` handler
+ *   removes any cache whose key starts with "childhood-" but is not the current one.
+ *
+ * Kill switch
+ *   Open any page with ?nosw=1 once. The bootstrap in js/common.js will unregister
+ *   every service worker and wipe every cache for this origin.
+ */
+
+// Bump this string to ship a new cache. Keep it short and unique.
+const VERSION = "2026-05-23-1";
+const CACHE_NAME = `childhood-${VERSION}`;
+
+// App shell precache: only the global resources used by every page.
+// Per-game pages and assets are cached on demand at runtime.
+const PRECACHE_URLS = [
+  "./",
+  "./index.html",
+  "./manifest.webmanifest",
+  "./css/normalize.css",
+  "./css/jquery-yys-slider.css",
+  "./css/index.css",
+  "./js/common.js",
+  "./js/jquery-yys-slider.js",
+  "./images/logo.svg",
+  "./images/logo-icon.svg",
+  "./images/pwa-icon.svg",
+  "./images/pwa-icon-maskable.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) =>
+      // Use Promise.all + per-item catch so one missing asset
+      // does not abort the whole install step.
+      Promise.all(
+        PRECACHE_URLS.map((url) =>
+          cache
+            .add(new Request(url, { cache: "reload" }))
+            .catch((err) => console.warn("[SW] precache failed:", url, err))
+        )
+      )
+    )
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    Promise.all([
+      // Drop caches from previous versions.
+      caches
+        .keys()
+        .then((keys) =>
+          Promise.all(
+            keys
+              .filter((k) => k.startsWith("childhood-") && k !== CACHE_NAME)
+              .map((k) => caches.delete(k))
+          )
+        ),
+      // Take control of already-open pages without forcing a reload.
+      self.clients.claim(),
+    ])
+  );
+});
+
+// Allow the page to ask the waiting worker to activate immediately.
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+
+  // Only intercept GET; let POST / PUT / etc. go straight to the network.
+  if (req.method !== "GET") return;
+
+  // Parse URL safely, then skip cross-origin (CDN, analytics, ...).
+  let url;
+  try {
+    url = new URL(req.url);
+  } catch {
+    return;
+  }
+  if (url.origin !== self.location.origin) return;
+
+  // Never intercept the SW file itself.
+  if (url.pathname.endsWith("/sw.js")) return;
+
+  const accept = req.headers.get("accept") || "";
+  const isHtml =
+    req.mode === "navigate" ||
+    accept.includes("text/html") ||
+    url.pathname.endsWith(".html") ||
+    url.pathname.endsWith("/");
+
+  if (isHtml) {
+    event.respondWith(networkFirst(req));
+  } else {
+    event.respondWith(staleWhileRevalidate(req));
+  }
+});
+
+/**
+ * Network-first: try network, fall back to cache, then to a generic offline
+ * response. Suitable for HTML so users always see fresh content when online.
+ */
+async function networkFirst(req) {
+  const cache = await caches.open(CACHE_NAME);
+  try {
+    const fresh = await fetch(req);
+    if (fresh && fresh.status === 200 && fresh.type === "basic") {
+      cache.put(req, fresh.clone()).catch(() => {});
+    }
+    return fresh;
+  } catch {
+    const cached = await cache.match(req);
+    if (cached) return cached;
+    // Last-resort fallback: site shell.
+    const shell = await cache.match("./index.html");
+    if (shell) return shell;
+    return new Response("<h1>当前离线</h1><p>请检查网络连接后重试。</p>", {
+      status: 503,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+}
+
+/**
+ * Stale-while-revalidate: serve from cache immediately, refresh the cache in
+ * the background. Suitable for CSS / JS / images / fonts.
+ */
+async function staleWhileRevalidate(req) {
+  const cache = await caches.open(CACHE_NAME);
+  const cached = await cache.match(req);
+  const networkPromise = fetch(req)
+    .then((res) => {
+      if (res && res.status === 200 && res.type === "basic") {
+        cache.put(req, res.clone()).catch(() => {});
+      }
+      return res;
+    })
+    .catch(() => cached);
+  return cached || networkPromise;
+}


### PR DESCRIPTION
## Summary

把站点改造为合规的 PWA，**不影响通过浏览器直接访问**。

## Changes

### 新增
- `manifest.webmanifest` —— 含 `name`/`short_name`/`start_url`/`scope`/`display: standalone`/`theme_color`/`icons` 等字段，满足 Chromium 安装条件。
- `images/pwa-icon.svg` —— `purpose: any` 主图标，512×512 满铺。
- `images/pwa-icon-maskable.svg` —— `purpose: maskable`，关键内容收缩到中央 80% 安全区。
- `sw.js` —— Service Worker：HTML 走 network-first，静态资源走 stale-while-revalidate，跨域请求直通，附带离线兜底页。

### 修改
- `index.html` —— 注入 PWA 元数据（`<link rel="manifest">`、`theme-color`、`apple-touch-icon`、`mobile-web-app-capable`、`apple-mobile-web-app-*`）。
- `js/common.js` —— 末尾追加 SW 注册引导：
  - `?nosw=1` kill switch：清除全部 SW 注册和缓存
  - 仅在 `https:` / `localhost` 注册，`file://` 直接跳过
  - SW URL 自动相对站点根（含子页面 `apps/x/y/`)
  - 注册失败静默吞掉
- `eslint.config.js` —— globals 补 `URLSearchParams`/`caches`；为 `sw.js` 单独配 service worker 上下文 globals（`self`/`Request`/`Response`/`clients` 等）。

## Verification

- ESLint：`sw.js` + `js/common.js` 0 错误 0 警告
- Vitest：25 个套件 / 1531 个测试全部通过
- 直接 `file://` 打开 HTML：`location.protocol !== 'https:'` 分支命中，SW 不注册，体验无变化

## 后续可选

- `static.yml` 加一步把 `sw.js` 的 `VERSION` 替换为 `${{ github.sha }}`，让缓存随 commit 自动失效
- 在 `js/common.js` 监听 `controllerchange` 弹「已更新，点击刷新」提示
