### PR TITLE
Unify current-player and winner labels across all games

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig: https://editorconfig.org
+# Tells editors (VS Code, IntelliJ, etc.) to keep line endings consistent
+# regardless of OS, so files don't drift to CRLF on Windows.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Windows-only scripts: keep CRLF or cmd/powershell may misbehave
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,41 @@
+# Default behavior: normalize line endings to LF on commit, keep working
+# tree as LF. This eliminates "phantom" diffs caused by Windows editors
+# silently saving files with CRLF.
+* text=auto eol=lf
+
+# Explicit text files (defensive, in case detection misclassifies)
+*.js     text eol=lf
+*.mjs    text eol=lf
+*.cjs    text eol=lf
+*.ts     text eol=lf
+*.json   text eol=lf
+*.md     text eol=lf
+*.html   text eol=lf
+*.css    text eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.toml   text eol=lf
+*.xml    text eol=lf
+*.svg    text eol=lf
+
+# Windows-only scripts must stay CRLF or they break
+*.bat    text eol=crlf
+*.cmd    text eol=crlf
+*.ps1    text eol=crlf
+
+# Binary files (don't touch)
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.webp   binary
+*.mp3    binary
+*.wav    binary
+*.ogg    binary
+*.woff   binary
+*.woff2  binary
+*.ttf    binary
+*.eot    binary
+*.zip    binary
+*.gz     binary

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -554,8 +554,16 @@ if (typeof document !== "undefined") {
       }
     }
 
-    // Status bar
-    document.getElementById("current-player").textContent = getPlayerName(state.currentPlayer);
+    // Status bar - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === RED ? WHITE : RED]
+        : [RED, WHITE],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === RED ? "text-red" : "text-white-piece");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -586,7 +594,7 @@ if (typeof document !== "undefined") {
     } else if (state.mustCapture) {
       updateMessage("必须吃子！请选择吃子棋子", "info");
     } else {
-      updateMessage("轮到 " + getPlayerName(state.currentPlayer) + " 行动", "info");
+      updateMessage("轮到 " + label.text + " 行动", "info");
     }
   }
 
@@ -842,6 +850,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     gameState = createGameState(mode);
     gameState.currentPlayer = firstPlayer || RED;
+    gameState.firstPlayer = firstPlayer || RED;
 
     if (mode === "pve") {
       if (firstPlayer === RED) {

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -617,7 +617,16 @@ if (typeof document !== "undefined") {
   function showGameOver(state) {
     const winnerText = document.getElementById("winner-text");
     if (state.winner) {
-      winnerText.textContent = getPlayerName(state.winner) + " 获胜！";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === RED ? WHITE : RED]
+          : [RED, WHITE],
+      });
+      winnerText.textContent = label.text + " 获胜！";
     } else {
       winnerText.textContent = "平局！";
     }

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -1524,11 +1524,16 @@ if (typeof document !== "undefined") {
 
   function showGameOverScreen(winner) {
     if (winner) {
-      let winnerName = winner === RED ? "红方" : "蓝方";
-      if (gameState.oppType === "pve") {
-        winnerName = winner === gameState.playerTeam ? "你赢了！" : "电脑获胜！";
-      }
-      $winnerText.textContent = winnerName;
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+      const label = getCurrentPlayerLabel({
+        mode: gameState.oppType,
+        currentSide: winner,
+        playerSide: gameState.playerTeam,
+        sidesOrder: gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === RED ? BLUE : RED]
+          : [RED, BLUE],
+      });
+      $winnerText.textContent = label.text + " 获胜！";
     } else {
       $winnerText.textContent = "平局！";
     }

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -1443,7 +1443,16 @@ if (typeof document !== "undefined") {
     const s = gameState;
 
     if (s.currentTeam) {
-      $currentTeam.textContent = s.currentTeam === RED ? "红方" : "蓝方";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+      const label = getCurrentPlayerLabel({
+        mode: s.oppType,
+        currentSide: s.currentTeam,
+        playerSide: s.playerTeam,
+        sidesOrder: s.firstPlayer
+          ? [s.firstPlayer, s.firstPlayer === RED ? BLUE : RED]
+          : [RED, BLUE],
+      });
+      $currentTeam.textContent = label.text;
       $currentTeam.className =
         "team-indicator " + (s.currentTeam === RED ? "red-text" : "blue-text");
     } else {
@@ -1588,8 +1597,16 @@ if (typeof document !== "undefined") {
     if (gameState.oppType === "pve" && gameState.currentTeam === gameState.aiTeam) {
       triggerAI();
     } else {
-      const teamName = gameState.currentTeam === RED ? "红方" : "蓝方";
-      showMessage(teamName + "的回合", "");
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) in turn message
+      const turnLabel = getCurrentPlayerLabel({
+        mode: gameState.oppType,
+        currentSide: gameState.currentTeam,
+        playerSide: gameState.playerTeam,
+        sidesOrder: gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === RED ? BLUE : RED]
+          : [RED, BLUE],
+      });
+      showMessage(turnLabel.text + "的回合", "");
     }
   }
 

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -717,9 +717,7 @@ if (typeof document !== "undefined") {
     if (gameState.firstPlayer) {
       const startIdx = gameState.players.indexOf(gameState.firstPlayer);
       if (startIdx > 0) {
-        sidesOrder = gameState.players
-          .slice(startIdx)
-          .concat(gameState.players.slice(0, startIdx));
+        sidesOrder = gameState.players.slice(startIdx).concat(gameState.players.slice(0, startIdx));
       }
     }
     const label = getCurrentPlayerLabel({
@@ -822,9 +820,7 @@ if (typeof document !== "undefined") {
     if (gameState.firstPlayer) {
       const startIdx = gameState.players.indexOf(gameState.firstPlayer);
       if (startIdx > 0) {
-        sidesOrder = gameState.players
-          .slice(startIdx)
-          .concat(gameState.players.slice(0, startIdx));
+        sidesOrder = gameState.players.slice(startIdx).concat(gameState.players.slice(0, startIdx));
       }
     }
     const label = getCurrentPlayerLabel({

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -742,7 +742,23 @@ if (typeof document !== "undefined") {
   function showGameOver() {
     const winnerText = document.getElementById("winner-text");
     if (gameState.winner) {
-      winnerText.textContent = PLAYER_COLORS[gameState.winner].name + " 获胜！";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2/... (PVP), reordered by firstPlayer
+      let sidesOrder = gameState.players;
+      if (gameState.firstPlayer) {
+        const startIdx = gameState.players.indexOf(gameState.firstPlayer);
+        if (startIdx > 0) {
+          sidesOrder = gameState.players
+            .slice(startIdx)
+            .concat(gameState.players.slice(0, startIdx));
+        }
+      }
+      const label = getCurrentPlayerLabel({
+        mode: gameState.mode,
+        currentSide: gameState.winner,
+        playerSide: gameState.playerTeam,
+        sidesOrder: sidesOrder,
+      });
+      winnerText.textContent = label.text + " 获胜！";
     } else {
       winnerText.textContent = "平局！";
     }

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -711,8 +711,25 @@ if (typeof document !== "undefined") {
   }
 
   function updateStatusBar() {
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2/... (PVP)
+    // Reorder players so that the firstPlayer (RPS winner) is 玩家1.
+    let sidesOrder = gameState.players;
+    if (gameState.firstPlayer) {
+      const startIdx = gameState.players.indexOf(gameState.firstPlayer);
+      if (startIdx > 0) {
+        sidesOrder = gameState.players
+          .slice(startIdx)
+          .concat(gameState.players.slice(0, startIdx));
+      }
+    }
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: gameState.currentPlayer,
+      playerSide: gameState.playerTeam,
+      sidesOrder: sidesOrder,
+    });
     const currentConfig = PLAYER_COLORS[gameState.currentPlayer];
-    document.getElementById("current-player").textContent = currentConfig.name;
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + currentConfig.textClass;
     document.getElementById("turn-count").textContent = gameState.turnCount;
@@ -800,7 +817,23 @@ if (typeof document !== "undefined") {
 
     drawBoard();
     updateStatusBar();
-    updateMessage("轮到 " + PLAYER_COLORS[gameState.currentPlayer].name + " 行动", "info");
+    // Reuse updateStatusBar's label logic for the message
+    let sidesOrder = gameState.players;
+    if (gameState.firstPlayer) {
+      const startIdx = gameState.players.indexOf(gameState.firstPlayer);
+      if (startIdx > 0) {
+        sidesOrder = gameState.players
+          .slice(startIdx)
+          .concat(gameState.players.slice(0, startIdx));
+      }
+    }
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: gameState.currentPlayer,
+      playerSide: gameState.playerTeam,
+      sidesOrder: sidesOrder,
+    });
+    updateMessage("轮到 " + label.text + " 行动", "info");
 
     if (gameState.mode === "pve" && gameState.currentPlayer === gameState.aiTeam) {
       triggerAI();
@@ -847,6 +880,7 @@ if (typeof document !== "undefined") {
     if (firstPlayer) {
       gameState.currentPlayer = firstPlayer;
     }
+    gameState.firstPlayer = gameState.currentPlayer;
 
     if (mode === "pve") {
       // Determine player and AI teams
@@ -891,7 +925,23 @@ if (typeof document !== "undefined") {
 
     drawBoard();
     updateStatusBar();
-    updateMessage("游戏开始！" + PLAYER_COLORS[gameState.currentPlayer].name + " 先手", "info");
+    // Build initial message via shared label helper for consistent naming
+    let sidesOrderInit = gameState.players;
+    if (gameState.firstPlayer) {
+      const startIdxInit = gameState.players.indexOf(gameState.firstPlayer);
+      if (startIdxInit > 0) {
+        sidesOrderInit = gameState.players
+          .slice(startIdxInit)
+          .concat(gameState.players.slice(0, startIdxInit));
+      }
+    }
+    const initLabel = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: gameState.currentPlayer,
+      playerSide: gameState.playerTeam,
+      sidesOrder: sidesOrderInit,
+    });
+    updateMessage("游戏开始！" + initLabel.text + " 先手", "info");
 
     const svg = document.getElementById("board-svg");
     svg.onclick = handleSvgClick;

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -881,7 +881,16 @@ if (typeof document !== "undefined") {
       }
     }
 
-    document.getElementById("current-player").textContent = getPlayerName(state.currentPlayer);
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === RED ? BLACK : RED]
+        : [RED, BLACK],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === RED ? "text-red" : "text-black-side");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -908,7 +917,7 @@ if (typeof document !== "undefined") {
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
       updateMessage("轮到AI行动", "info");
     } else {
-      updateMessage("轮到 " + getPlayerName(state.currentPlayer) + " 行动", "info");
+      updateMessage("轮到 " + label.text + " 行动", "info");
     }
   }
 
@@ -1041,6 +1050,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     gameState = createGameState(mode);
     gameState.currentPlayer = firstPlayer || RED;
+    gameState.firstPlayer = firstPlayer || RED;
     gameState.boardFlipped = false;
 
     if (mode === "pve") {

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -940,7 +940,16 @@ if (typeof document !== "undefined") {
   function showGameOver(state) {
     const winnerText = document.getElementById("winner-text");
     if (state.winner) {
-      winnerText.textContent = getPlayerName(state.winner) + " 获胜！";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === RED ? BLACK : RED]
+          : [RED, BLACK],
+      });
+      winnerText.textContent = label.text + " 获胜！";
       winnerText.className = state.winner === RED ? "text-red" : "text-black-side";
     } else {
       winnerText.textContent = "平局！";

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -769,8 +769,16 @@ if (typeof document !== "undefined") {
       drawKoMarker(state.koPoint.x, state.koPoint.y);
     }
 
-    // Update status bar
-    document.getElementById("current-player").textContent = getPlayerName(state.currentPlayer);
+    // Update status bar - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === BLACK ? WHITE : BLACK]
+        : [BLACK, WHITE],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === BLACK ? "text-black" : "text-white-stone");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -794,7 +802,7 @@ if (typeof document !== "undefined") {
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
       updateMessage("轮到AI行动", "info");
     } else {
-      updateMessage("轮到 " + getPlayerName(state.currentPlayer) + " 落子", "info");
+      updateMessage("轮到 " + label.text + " 落子", "info");
     }
   }
 
@@ -929,7 +937,15 @@ if (typeof document !== "undefined") {
     }
 
     gameState.currentPlayer = getOpponent(gameState.currentPlayer);
-    updateMessage(getPlayerName(gameState.currentPlayer) + "选择Pass，轮到对方", "info");
+    const passLabel = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: gameState.currentPlayer,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === BLACK ? WHITE : BLACK]
+        : [BLACK, WHITE],
+    });
+    updateMessage("对方选择Pass，轮到 " + passLabel.text, "info");
     renderGame(gameState);
 
     if (gameState.mode === "pve" && gameState.currentPlayer === gameState.aiTeam) {
@@ -973,6 +989,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     gameState = createGameState(mode);
     gameState.currentPlayer = firstPlayer || BLACK;
+    gameState.firstPlayer = firstPlayer || BLACK;
 
     if (mode === "pve") {
       if (firstPlayer === BLACK) {

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -819,18 +819,21 @@ if (typeof document !== "undefined") {
     const blackTotal = score.black + state.capturesBlack;
     const whiteTotal = score.white + state.capturesWhite + state.komi;
 
-    if (state.winner) {
-      winnerText.textContent = getPlayerName(state.winner) + " 获胜！";
-    } else {
-      // Calculate final score
-      if (blackTotal > whiteTotal) {
-        winnerText.textContent = "黑棋 获胜！";
-        state.winner = BLACK;
-      } else {
-        winnerText.textContent = "白棋 获胜！";
-        state.winner = WHITE;
-      }
+    // Determine winner if not yet decided (count-based ending)
+    if (!state.winner) {
+      state.winner = blackTotal > whiteTotal ? BLACK : WHITE;
     }
+
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.winner,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === BLACK ? WHITE : BLACK]
+        : [BLACK, WHITE],
+    });
+    winnerText.textContent = label.text + " 获胜！";
 
     scoreDetail.innerHTML =
       "黑棋：" +

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -412,8 +412,16 @@ if (typeof document !== "undefined") {
       drawWinLine(state.winLine);
     }
 
-    // Update status bar
-    document.getElementById("current-player").textContent = getPlayerName(state.currentPlayer);
+    // Update status bar - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === BLACK ? WHITE : BLACK]
+        : [BLACK, WHITE],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === BLACK ? "text-black" : "text-white-stone");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -437,7 +445,7 @@ if (typeof document !== "undefined") {
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
       updateMessage("轮到AI行动", "info");
     } else {
-      updateMessage("轮到 " + getPlayerName(state.currentPlayer) + " 落子", "info");
+      updateMessage("轮到 " + label.text + " 落子", "info");
     }
   }
 
@@ -528,6 +536,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     gameState = createGameState(mode);
     gameState.currentPlayer = firstPlayer || BLACK;
+    gameState.firstPlayer = firstPlayer || BLACK;
 
     if (mode === "pve") {
       if (firstPlayer === BLACK) {

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -458,7 +458,16 @@ if (typeof document !== "undefined") {
   function showGameOver(state) {
     const winnerText = document.getElementById("winner-text");
     if (state.winner) {
-      winnerText.textContent = getPlayerName(state.winner) + " 获胜！";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === BLACK ? WHITE : BLACK]
+          : [BLACK, WHITE],
+      });
+      winnerText.textContent = label.text + " 获胜！";
     } else {
       winnerText.textContent = "平局！";
     }

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -952,7 +952,16 @@ if (typeof document !== "undefined") {
         if (state.board[c][r] !== EMPTY) drawPiece(c, r, state.board[c][r]);
       }
     }
-    document.getElementById("current-player").textContent = getPlayerName(state.currentPlayer);
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === WHITE ? BLACK : WHITE]
+        : [WHITE, BLACK],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === WHITE ? "text-white-side" : "text-black-side");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -972,7 +981,7 @@ if (typeof document !== "undefined") {
     else if (state.mode === "pve" && state.currentPlayer === state.aiTeam)
       updateMessage("轮到AI行动", "info");
     else if (state.promotionPending) updateMessage("选择升变棋子", "info");
-    else updateMessage("轮到 " + getPlayerName(state.currentPlayer) + " 行动", "info");
+    else updateMessage("轮到 " + label.text + " 行动", "info");
   }
 
   function countPieces(board, color) {
@@ -1146,6 +1155,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, playerTeam) {
     gameState = createGameState(mode);
     gameState.currentPlayer = WHITE; // White always moves first
+    gameState.firstPlayer = WHITE;
     gameState.boardFlipped = false;
     if (mode === "pve") {
       gameState.playerTeam = playerTeam || WHITE;

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -1003,7 +1003,16 @@ if (typeof document !== "undefined") {
   function showGameOver(state) {
     const winnerText = document.getElementById("winner-text");
     if (state.winner) {
-      winnerText.textContent = getPlayerName(state.winner) + " 获胜！";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === WHITE ? BLACK : WHITE]
+          : [WHITE, BLACK],
+      });
+      winnerText.textContent = label.text + " 获胜！";
       winnerText.className = state.winner === WHITE ? "text-white-side" : "text-black-side";
     } else {
       winnerText.textContent = "和棋！";

--- a/apps/board-game/reversi/game.js
+++ b/apps/board-game/reversi/game.js
@@ -493,10 +493,18 @@ function showGameOver(state) {
   const counts = countPieces(state.board);
 
   if (state.winner === "draw") {
-    winnerText.textContent = `游戏结束！Draw！黑棋: ${counts.black} 白棋: ${counts.white}`;
+    winnerText.textContent = `游戏结束！平局！黑棋: ${counts.black} 白棋: ${counts.white}`;
   } else {
-    const winnerName = state.winner === PLAYER_BLACK ? "黑棋" : "白棋";
-    winnerText.textContent = `游戏结束！${winnerName}获胜！黑棋: ${counts.black} 白棋: ${counts.white}`;
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.winner,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK]
+        : [PLAYER_BLACK, PLAYER_WHITE],
+    });
+    winnerText.textContent = `游戏结束！${label.text} 获胜！黑棋: ${counts.black} 白棋: ${counts.white}`;
   }
 
   document.getElementById("game-over").style.display = "flex";

--- a/apps/board-game/reversi/game.js
+++ b/apps/board-game/reversi/game.js
@@ -387,9 +387,16 @@ function initBoard() {
  * @param {GameState} state - game state
  */
 function renderGame(state) {
-  // Update status bar
-  document.getElementById("current-team").textContent =
-    state.currentPlayer === PLAYER_BLACK ? "黑棋" : "白棋";
+  // Update status bar - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+  const label = getCurrentPlayerLabel({
+    mode: state.mode,
+    currentSide: state.currentPlayer,
+    playerSide: state.playerTeam,
+    sidesOrder: state.firstPlayer
+      ? [state.firstPlayer, state.firstPlayer === PLAYER_BLACK ? PLAYER_WHITE : PLAYER_BLACK]
+      : [PLAYER_BLACK, PLAYER_WHITE],
+  });
+  document.getElementById("current-team").textContent = label.text;
   document.getElementById("current-team").className =
     state.currentPlayer === PLAYER_BLACK
       ? "team-indicator black-text"
@@ -565,6 +572,7 @@ function handleCellClick(x, y) {
 function startGame(mode, firstPlayer = PLAYER_BLACK) {
   gameState = createGameState(mode);
   gameState.currentPlayer = firstPlayer;
+  gameState.firstPlayer = firstPlayer;
   gameState.validMoves = getValidMoves(gameState.board, firstPlayer);
 
   // Set player and AI for PvE mode

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -306,7 +306,16 @@ if (typeof document !== "undefined") {
     if (state.winner === "draw") {
       winnerText.textContent = "平局！";
     } else {
-      winnerText.textContent = state.winner + " 获胜！";
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of X/O
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === PLAYER_X ? PLAYER_O : PLAYER_X]
+          : [PLAYER_X, PLAYER_O],
+      });
+      winnerText.textContent = label.text + " 获胜！";
     }
     document.getElementById("game-over").style.display = "flex";
   }

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -242,8 +242,16 @@ if (typeof document !== "undefined") {
   }
 
   function renderGame(state) {
-    document.getElementById("current-player").textContent =
-      state.currentPlayer === PLAYER_X ? "X (先手)" : "O (后手)";
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_X ? PLAYER_O : PLAYER_X]
+        : [PLAYER_X, PLAYER_O],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === PLAYER_X ? "text-x" : "text-o");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -361,6 +369,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     gameState = createGameState(mode);
     gameState.currentPlayer = firstPlayer || PLAYER_X;
+    gameState.firstPlayer = firstPlayer || PLAYER_X;
 
     if (mode === "pve") {
       if (firstPlayer === PLAYER_X) {

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -428,14 +428,24 @@ if (typeof document !== "undefined") {
   }
 
   function updateStatus(state) {
-    // Current team
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    // Avoids leaking color identity, especially before the first flip.
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentTeam,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+      assigned: state.teamAssigned,
+      aiFirst: state.aiFirst,
+    });
+    $currentTeam.textContent = label.text;
     if (state.currentTeam) {
-      const teamName = state.currentTeam === "red" ? "红方" : "蓝方";
-      $currentTeam.textContent = teamName;
       $currentTeam.className =
         "team-indicator " + (state.currentTeam === "red" ? "red-text" : "blue-text");
     } else {
-      $currentTeam.textContent = "—";
+      $currentTeam.className = "team-indicator";
     }
 
     // Turn count
@@ -886,12 +896,16 @@ if (typeof document !== "undefined") {
         showMessage("你的回合", "");
       }
     } else {
-      // PVP
-      const teamName = gameState.currentTeam === "red" ? "红方" : "蓝方";
+      // PVP - show 玩家1 / 玩家2 instead of color
       if (!gameState.teamAssigned) {
         showMessage("请翻开一张牌", "");
       } else {
-        showMessage(teamName + "的回合", "");
+        const sidesOrder = gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"];
+        const idx = sidesOrder.indexOf(gameState.currentTeam);
+        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+        showMessage(playerName + "的回合", "");
       }
     }
   }

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -569,8 +569,16 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
-    const winnerName = winner === "red" ? "红方" : "蓝方";
-    $winnerText.textContent = winnerName + " 获胜！";
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: winner,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+    });
+    $winnerText.textContent = label.text + " 获胜！";
     $gameOver.style.display = "flex";
   }
 

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -395,8 +395,16 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
-    const winnerName = winner === "red" ? "红方" : "蓝方";
-    $winnerText.textContent = winnerName + " 获胜！";
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: winner,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+    });
+    $winnerText.textContent = label.text + " 获胜！";
     $gameOver.style.display = "flex";
   }
 

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -474,14 +474,23 @@ if (typeof document !== "undefined") {
   // ---- 4.4 Status update functions ----
 
   function updateStatus(state) {
-    // Current team
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    // Avoids leaking color identity, especially before the first flip.
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentTeam,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+      assigned: state.teamAssigned,
+      aiFirst: state.aiFirst,
+    });
+    $currentTeam.textContent = label.text;
     if (state.currentTeam) {
-      const teamName = state.currentTeam === "red" ? "红方" : "蓝方";
-      $currentTeam.textContent = teamName;
       $currentTeam.className =
         "team-indicator " + (state.currentTeam === "red" ? "red-text" : "blue-text");
     } else {
-      $currentTeam.textContent = "—";
       $currentTeam.className = "team-indicator";
     }
 
@@ -885,12 +894,16 @@ if (typeof document !== "undefined") {
         showMessage("你的回合", "");
       }
     } else {
-      // PVP
+      // PVP - show 玩家1 / 玩家2 instead of color
       if (!gameState.teamAssigned) {
         showMessage("请翻开一张牌", "");
       } else {
-        const teamName = gameState.currentTeam === "red" ? "红方" : "蓝方";
-        showMessage(teamName + "的回合", "");
+        const sidesOrder = gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"];
+        const idx = sidesOrder.indexOf(gameState.currentTeam);
+        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+        showMessage(playerName + "的回合", "");
       }
     }
   }

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1077,8 +1077,16 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
-    const winnerName = winner === "red" ? "红方" : "蓝方";
-    $winnerText.textContent = winnerName + "获胜！";
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: winner,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+    });
+    $winnerText.textContent = label.text + "获胜！";
     $gameOver.style.display = "flex";
   }
 

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -787,13 +787,19 @@ if (typeof document !== "undefined") {
   function updateStatus(state) {
     // Current team
     if (state.currentTeam) {
-      if (state.currentTeam === "red") {
-        $currentTeam.textContent = "红方";
-        $currentTeam.className = "team-indicator red-text";
-      } else {
-        $currentTeam.textContent = "蓝方";
-        $currentTeam.className = "team-indicator blue-text";
-      }
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.currentTeam,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"],
+        assigned: state.teamAssigned,
+        aiFirst: state.aiFirst,
+      });
+      $currentTeam.textContent = label.text;
+      $currentTeam.className =
+        "team-indicator " + (state.currentTeam === "red" ? "red-text" : "blue-text");
     } else {
       $currentTeam.textContent = "—";
       $currentTeam.className = "team-indicator";
@@ -1214,12 +1220,16 @@ if (typeof document !== "undefined") {
         showMessage("你的回合", "");
       }
     } else {
-      // PVP
+      // PVP - show 玩家1 / 玩家2 instead of color
       if (!gameState.teamAssigned) {
         showMessage("请翻开一张牌", "");
       } else {
-        const teamName = gameState.currentTeam === "red" ? "红方" : "蓝方";
-        showMessage(teamName + "的回合", "");
+        const sidesOrder = gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"];
+        const idx = sidesOrder.indexOf(gameState.currentTeam);
+        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+        showMessage(playerName + "的回合", "");
       }
     }
   }

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -553,8 +553,17 @@ if (typeof document !== "undefined") {
   function updateStatus(state) {
     // Current team
     if (state.currentTeam) {
-      const teamName = state.currentTeam === "dragon" ? "龙队" : "虎队";
-      $currentTeam.textContent = teamName;
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.currentTeam,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === "dragon" ? "tiger" : "dragon"]
+          : ["dragon", "tiger"],
+        assigned: state.teamAssigned,
+        aiFirst: state.aiFirst,
+      });
+      $currentTeam.textContent = label.text;
       $currentTeam.className =
         "team-indicator " + (state.currentTeam === "dragon" ? "dragon-text" : "tiger-text");
     } else {
@@ -932,12 +941,16 @@ if (typeof document !== "undefined") {
         showMessage("你的回合", "");
       }
     } else {
-      // PVP
-      const teamName = gameState.currentTeam === "dragon" ? "龙队" : "虎队";
+      // PVP - show 玩家1 / 玩家2 instead of dragon/tiger
       if (!gameState.teamAssigned) {
         showMessage("请翻开一张牌", "");
       } else {
-        showMessage(teamName + "的回合", "");
+        const sidesOrder = gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === "dragon" ? "tiger" : "dragon"]
+          : ["dragon", "tiger"];
+        const idx = sidesOrder.indexOf(gameState.currentTeam);
+        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+        showMessage(playerName + "的回合", "");
       }
     }
   }

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -677,8 +677,16 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
-    const winnerName = winner === "dragon" ? "龙队" : "虎队";
-    $winnerText.textContent = winnerName + " 获胜！";
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of dragon/tiger
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: winner,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "dragon" ? "tiger" : "dragon"]
+        : ["dragon", "tiger"],
+    });
+    $winnerText.textContent = label.text + " 获胜！";
     $gameOver.style.display = "flex";
   }
 

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -703,8 +703,16 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
-    const winnerName = winner === "red" ? "红方" : "蓝方";
-    $winnerText.textContent = winnerName + " 获胜！";
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: winner,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+    });
+    $winnerText.textContent = label.text + " 获胜！";
     $gameOver.style.display = "flex";
   }
 

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -581,8 +581,17 @@ if (typeof document !== "undefined") {
   function updateStatus(state) {
     // Current team
     if (state.currentTeam) {
-      const teamName = state.currentTeam === "red" ? "红方" : "蓝方";
-      $currentTeam.textContent = teamName;
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.currentTeam,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"],
+        assigned: state.teamAssigned,
+        aiFirst: state.aiFirst,
+      });
+      $currentTeam.textContent = label.text;
       $currentTeam.className =
         "team-indicator " + (state.currentTeam === "red" ? "red-text" : "blue-text");
     } else {
@@ -996,12 +1005,16 @@ if (typeof document !== "undefined") {
         showMessage("你的回合", "");
       }
     } else {
-      // PVP or team not assigned
-      const teamName = gameState.currentTeam === "red" ? "红方" : "蓝方";
+      // PVP - show 玩家1 / 玩家2 instead of color
       if (!gameState.teamAssigned) {
         showMessage("请翻开一张牌", "");
       } else {
-        showMessage(teamName + "的回合", "");
+        const sidesOrder = gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"];
+        const idx = sidesOrder.indexOf(gameState.currentTeam);
+        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+        showMessage(playerName + "的回合", "");
       }
     }
   }

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -398,8 +398,16 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
-    const winnerName = winner === "red" ? "红方" : "蓝方";
-    $winnerText.textContent = winnerName + " 获胜！";
+    // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
+    const label = getCurrentPlayerLabel({
+      mode: gameState.mode,
+      currentSide: winner,
+      playerSide: gameState.playerTeam,
+      sidesOrder: gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"],
+    });
+    $winnerText.textContent = label.text + " 获胜！";
     $gameOver.style.display = "flex";
   }
 

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -472,8 +472,17 @@ if (typeof document !== "undefined") {
   function updateStatus(state) {
     // Current team
     if (state.currentTeam) {
-      const teamName = state.currentTeam === "red" ? "红方" : "蓝方";
-      $currentTeam.textContent = teamName;
+      const label = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.currentTeam,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"],
+        assigned: state.teamAssigned,
+        aiFirst: state.aiFirst,
+      });
+      $currentTeam.textContent = label.text;
       $currentTeam.className =
         "team-indicator " + (state.currentTeam === "red" ? "red-text" : "blue-text");
     } else {
@@ -883,12 +892,16 @@ if (typeof document !== "undefined") {
         showMessage("你的回合", "");
       }
     } else {
-      // PVP
+      // PVP - show 玩家1 / 玩家2 instead of color
       if (!gameState.teamAssigned) {
         showMessage("请翻开一张牌", "");
       } else {
-        const teamName = gameState.currentTeam === "red" ? "红方" : "蓝方";
-        showMessage(teamName + "的回合", "");
+        const sidesOrder = gameState.firstPlayer
+          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+          : ["red", "blue"];
+        const idx = sidesOrder.indexOf(gameState.currentTeam);
+        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+        showMessage(playerName + "的回合", "");
       }
     }
   }

--- a/apps/childhood-board-game/bai-si-long/game.js
+++ b/apps/childhood-board-game/bai-si-long/game.js
@@ -501,9 +501,20 @@ if (typeof document !== "undefined") {
 
     if (state.gameOver) {
       var winnerText;
-      if (state.winner === PLAYER_A) winnerText = "上方 (A) 摆出四龙获胜！";
-      else if (state.winner === PLAYER_B) winnerText = "下方 (B) 摆出四龙获胜！";
-      else winnerText = "平局";
+      if (state.winner === PLAYER_A || state.winner === PLAYER_B) {
+        // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of position name
+        var winnerLabel = getCurrentPlayerLabel({
+          mode: state.mode,
+          currentSide: state.winner,
+          playerSide: state.playerTeam,
+          sidesOrder: state.firstPlayer
+            ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+            : [PLAYER_A, PLAYER_B],
+        });
+        winnerText = winnerLabel.text + " 摆出四龙获胜！";
+      } else {
+        winnerText = "平局";
+      }
       document.getElementById("winner-text").textContent = winnerText;
       document.getElementById("game-over").style.display = "flex";
     }

--- a/apps/childhood-board-game/bai-si-long/game.js
+++ b/apps/childhood-board-game/bai-si-long/game.js
@@ -474,8 +474,16 @@ if (typeof document !== "undefined") {
       if (text) text.textContent = label;
     });
 
-    document.getElementById("current-player").textContent =
-      state.currentPlayer === PLAYER_A ? "上方 (A)" : "下方 (B)";
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+        : [PLAYER_A, PLAYER_B],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === PLAYER_A ? "team-a" : "team-b");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -583,6 +591,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     state = createInitialState(mode);
     state.currentPlayer = firstPlayer || PLAYER_A;
+    state.firstPlayer = firstPlayer || PLAYER_A;
     if (mode === "pve") {
       // Human always plays the bottom side (B), AI plays the top (A).
       state.playerTeam = PLAYER_B;

--- a/apps/childhood-board-game/lang-chi-yang/game.js
+++ b/apps/childhood-board-game/lang-chi-yang/game.js
@@ -455,8 +455,16 @@ if (typeof document !== "undefined") {
     document.getElementById("pieces-b").textContent = state.piecesB;
 
     if (state.gameOver) {
-      var winnerText = state.winner === PLAYER_A ? "羊群获胜！" : "狼群获胜！";
-      document.getElementById("winner-text").textContent = winnerText;
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of role name
+      var winnerLabel = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+          : [PLAYER_A, PLAYER_B],
+      });
+      document.getElementById("winner-text").textContent = winnerLabel.text + " 获胜！";
       document.getElementById("game-over").style.display = "flex";
     }
   }

--- a/apps/childhood-board-game/lang-chi-yang/game.js
+++ b/apps/childhood-board-game/lang-chi-yang/game.js
@@ -438,9 +438,17 @@ if (typeof document !== "undefined") {
       }
     });
 
-    var playerLabel = state.currentPlayer === PLAYER_A ? "羊 (Sheep)" : "狼 (Wolf)";
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+        : [PLAYER_A, PLAYER_B],
+    });
     var playerClass = state.currentPlayer === PLAYER_A ? "team-a" : "team-b";
-    document.getElementById("current-player").textContent = playerLabel;
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className = "team-indicator " + playerClass;
     document.getElementById("turn-count").textContent = state.turnCount;
     document.getElementById("pieces-a").textContent = state.piecesA;
@@ -544,6 +552,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     state = createGameState(mode);
     state.currentPlayer = firstPlayer || PLAYER_A;
+    state.firstPlayer = firstPlayer || PLAYER_A;
     if (mode === "pve") {
       state.playerTeam = PLAYER_A;
       state.aiTeam = PLAYER_B;

--- a/apps/childhood-board-game/ma-yi-ban-jia/game.js
+++ b/apps/childhood-board-game/ma-yi-ban-jia/game.js
@@ -532,9 +532,20 @@ if (typeof document !== "undefined") {
 
     if (state.gameOver) {
       var winnerText;
-      if (state.winner === PLAYER_A) winnerText = "上方 (A) 占领对方家，获胜！";
-      else if (state.winner === PLAYER_B) winnerText = "下方 (B) 占领对方家，获胜！";
-      else winnerText = "平局";
+      if (state.winner === PLAYER_A || state.winner === PLAYER_B) {
+        // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of position name
+        var winnerLabel = getCurrentPlayerLabel({
+          mode: state.mode,
+          currentSide: state.winner,
+          playerSide: state.playerTeam,
+          sidesOrder: state.firstPlayer
+            ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+            : [PLAYER_A, PLAYER_B],
+        });
+        winnerText = winnerLabel.text + " 占领对方家，获胜！";
+      } else {
+        winnerText = "平局";
+      }
       document.getElementById("winner-text").textContent = winnerText;
       document.getElementById("game-over").style.display = "flex";
     }

--- a/apps/childhood-board-game/ma-yi-ban-jia/game.js
+++ b/apps/childhood-board-game/ma-yi-ban-jia/game.js
@@ -505,8 +505,16 @@ if (typeof document !== "undefined") {
       g.setAttribute("class", classes.join(" "));
     });
 
-    document.getElementById("current-player").textContent =
-      state.currentPlayer === PLAYER_A ? "上方 (A)" : "下方 (B)";
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+        : [PLAYER_A, PLAYER_B],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === PLAYER_A ? "team-a" : "team-b");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -622,6 +630,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     state = createInitialState(mode);
     state.currentPlayer = firstPlayer || PLAYER_A;
+    state.firstPlayer = firstPlayer || PLAYER_A;
     if (mode === "pve") {
       // Human always plays the bottom side (B); AI plays the top (A).
       state.playerTeam = PLAYER_B;

--- a/apps/childhood-board-game/si-bu-ding/game.js
+++ b/apps/childhood-board-game/si-bu-ding/game.js
@@ -523,9 +523,20 @@ if (typeof document !== "undefined") {
 
     if (state.gameOver) {
       var winnerText;
-      if (state.winner === PLAYER_A) winnerText = "上方 (A) 吃掉对方 3 子，获胜！";
-      else if (state.winner === PLAYER_B) winnerText = "下方 (B) 吃掉对方 3 子，获胜！";
-      else winnerText = "平局";
+      if (state.winner === PLAYER_A || state.winner === PLAYER_B) {
+        // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of position name
+        var winnerLabel = getCurrentPlayerLabel({
+          mode: state.mode,
+          currentSide: state.winner,
+          playerSide: state.playerTeam,
+          sidesOrder: state.firstPlayer
+            ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+            : [PLAYER_A, PLAYER_B],
+        });
+        winnerText = winnerLabel.text + " 吃掉对方 3 子，获胜！";
+      } else {
+        winnerText = "平局";
+      }
       document.getElementById("winner-text").textContent = winnerText;
       document.getElementById("game-over").style.display = "flex";
     }

--- a/apps/childhood-board-game/si-bu-ding/game.js
+++ b/apps/childhood-board-game/si-bu-ding/game.js
@@ -493,8 +493,16 @@ if (typeof document !== "undefined") {
       g.setAttribute("class", classes.join(" "));
     });
 
-    document.getElementById("current-player").textContent =
-      state.currentPlayer === PLAYER_A ? "上方 (A)" : "下方 (B)";
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+        : [PLAYER_A, PLAYER_B],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === PLAYER_A ? "team-a" : "team-b");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -609,6 +617,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     state = createInitialState(mode);
     state.currentPlayer = firstPlayer || PLAYER_A;
+    state.firstPlayer = firstPlayer || PLAYER_A;
     if (mode === "pve") {
       // Human always plays the bottom side (B); AI plays the top (A).
       state.playerTeam = PLAYER_B;

--- a/apps/childhood-board-game/xiao-mao-diao-yu/game.js
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/game.js
@@ -520,8 +520,16 @@ if (typeof document !== "undefined") {
     }
 
     if (state.gameOver) {
-      var winnerText = state.winner === PLAYER_A ? "猫获胜！" : "鱼获胜！";
-      document.getElementById("winner-text").textContent = winnerText;
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of role name
+      var winnerLabel = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+          : [PLAYER_A, PLAYER_B],
+      });
+      document.getElementById("winner-text").textContent = winnerLabel.text + " 获胜！";
       document.getElementById("game-over").style.display = "flex";
     }
   }

--- a/apps/childhood-board-game/xiao-mao-diao-yu/game.js
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/game.js
@@ -473,9 +473,16 @@ if (typeof document !== "undefined") {
       if (text) text.textContent = label;
     });
 
-    // Status bar
-    document.getElementById("current-player").textContent =
-      state.currentPlayer === PLAYER_A ? "猫" : "鱼";
+    // Status bar - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+        : [PLAYER_A, PLAYER_B],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === PLAYER_A ? "team-a" : "team-b");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -589,6 +596,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     state = createGameState(mode);
     state.currentPlayer = firstPlayer || PLAYER_A;
+    state.firstPlayer = firstPlayer || PLAYER_A;
     if (mode === "pve") {
       state.playerTeam = PLAYER_A;
       state.aiTeam = PLAYER_B;

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
@@ -523,8 +523,16 @@ if (typeof document !== "undefined") {
       if (text) text.textContent = label;
     });
 
-    document.getElementById("current-player").textContent =
-      state.currentPlayer === PLAYER_A ? "追兵 (A)" : "逃兵 (B)";
+    // Current acting side - shown as 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP)
+    const label = getCurrentPlayerLabel({
+      mode: state.mode,
+      currentSide: state.currentPlayer,
+      playerSide: state.playerTeam,
+      sidesOrder: state.firstPlayer
+        ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+        : [PLAYER_A, PLAYER_B],
+    });
+    document.getElementById("current-player").textContent = label.text;
     document.getElementById("current-player").className =
       "team-indicator " + (state.currentPlayer === PLAYER_A ? "team-a" : "team-b");
     document.getElementById("turn-count").textContent = state.turnCount;
@@ -619,6 +627,7 @@ if (typeof document !== "undefined") {
   function startGame(mode, firstPlayer) {
     state = createInitialState(mode);
     state.currentPlayer = firstPlayer || PLAYER_A;
+    state.firstPlayer = firstPlayer || PLAYER_A;
     if (mode === "pve") {
       // Default: human plays the chasers (A), AI plays the runner (B)
       state.playerTeam = PLAYER_A;

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
@@ -556,11 +556,22 @@ if (typeof document !== "undefined") {
           break;
         }
       }
+      // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of role name
+      var winnerLabel = getCurrentPlayerLabel({
+        mode: state.mode,
+        currentSide: state.winner,
+        playerSide: state.playerTeam,
+        sidesOrder: state.firstPlayer
+          ? [state.firstPlayer, state.firstPlayer === PLAYER_A ? PLAYER_B : PLAYER_A]
+          : [PLAYER_A, PLAYER_B],
+      });
       var winnerText;
       if (state.winner === PLAYER_B) {
-        winnerText = bAtRoot ? "逃兵获胜！成功逃到牛角根。" : "逃兵获胜！追兵无路可走。";
+        winnerText = bAtRoot
+          ? winnerLabel.text + " 获胜！成功逃到牛角根。"
+          : winnerLabel.text + " 获胜！追兵无路可走。";
       } else {
-        winnerText = "追兵获胜！逃兵被困进牛角尖。";
+        winnerText = winnerLabel.text + " 获胜！逃兵被困进牛角尖。";
       }
       document.getElementById("winner-text").textContent = winnerText;
       document.getElementById("game-over").style.display = "flex";

--- a/apps/common/game-utils.js
+++ b/apps/common/game-utils.js
@@ -45,9 +45,64 @@ function shuffleArray(arr) {
   return arr;
 }
 
+/**
+ * Resolve a generic display label for the current acting side.
+ * Returns "玩家"/"电脑" in PVE mode and "玩家1"/"玩家2"/... in PVP mode.
+ *
+ * This avoids leaking side identifiers like color/role names to the UI.
+ * It is especially useful for flip-card games where the side -> role
+ * mapping is not yet decided at game start.
+ *
+ * @param {Object} opts
+ * @param {string} [opts.mode] - 'pve' | 'pvp'
+ * @param {*} [opts.currentSide] - current side identifier (e.g. 'red', 1, 'dragon')
+ * @param {*} [opts.playerSide] - human side identifier (used in PVE)
+ * @param {Array} [opts.sidesOrder] - sides in turn order starting from the first to act (used in PVP)
+ * @param {boolean} [opts.assigned=true] - whether the side -> role mapping is decided
+ * @param {boolean} [opts.aiFirst] - whether the AI acts first (used in PVE before assignment)
+ * @returns {{text: string, role: 'unknown'|'player'|'ai'|'playerN'}}
+ */
+function getCurrentPlayerLabel(opts) {
+  const mode = opts && opts.mode;
+  const currentSide = opts ? opts.currentSide : null;
+  const playerSide = opts ? opts.playerSide : null;
+  const sidesOrder = opts ? opts.sidesOrder : null;
+  const assigned = !opts || opts.assigned !== false;
+  const aiFirst = opts ? opts.aiFirst : undefined;
+
+  if (currentSide == null) {
+    return { text: "—", role: "unknown" };
+  }
+
+  if (mode === "pve") {
+    if (assigned && playerSide != null) {
+      return currentSide === playerSide
+        ? { text: "玩家", role: "player" }
+        : { text: "电脑", role: "ai" };
+    }
+    // Unassigned PVE (e.g. flip games before first flip): use aiFirst flag
+    if (aiFirst === true) {
+      return { text: "电脑", role: "ai" };
+    }
+    if (aiFirst === false) {
+      return { text: "玩家", role: "player" };
+    }
+    return { text: "—", role: "unknown" };
+  }
+
+  // PVP mode (also default when mode is missing)
+  if (Array.isArray(sidesOrder) && sidesOrder.length > 0) {
+    const idx = sidesOrder.indexOf(currentSide);
+    if (idx >= 0) {
+      return { text: "玩家" + (idx + 1), role: "playerN" };
+    }
+  }
+  return { text: "玩家", role: "unknown" };
+}
+
 // ============================================================
 // Module exports (Node.js environment)
 // ============================================================
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { judgeRPS, getRPSName, shuffleArray };
+  module.exports = { judgeRPS, getRPSName, shuffleArray, getCurrentPlayerLabel };
 }

--- a/apps/common/game-utils.test.js
+++ b/apps/common/game-utils.test.js
@@ -73,3 +73,92 @@ describe("shuffleArray", () => {
     expect(result).toBe(arr);
   });
 });
+
+const { getCurrentPlayerLabel } = require("./game-utils.js");
+
+describe("getCurrentPlayerLabel", () => {
+  it("returns dash when currentSide is null", () => {
+    const r = getCurrentPlayerLabel({ mode: "pve", currentSide: null, playerSide: "red" });
+    expect(r.text).toBe("—");
+    expect(r.role).toBe("unknown");
+  });
+
+  it("returns dash when not assigned and aiFirst is unknown", () => {
+    const r = getCurrentPlayerLabel({
+      mode: "pve",
+      currentSide: "red",
+      playerSide: null,
+      assigned: false,
+    });
+    expect(r.text).toBe("—");
+    expect(r.role).toBe("unknown");
+  });
+
+  it("uses aiFirst when PVE is not assigned yet (player first)", () => {
+    const r = getCurrentPlayerLabel({
+      mode: "pve",
+      currentSide: "red",
+      assigned: false,
+      aiFirst: false,
+    });
+    expect(r.text).toBe("玩家");
+    expect(r.role).toBe("player");
+  });
+
+  it("uses aiFirst when PVE is not assigned yet (AI first)", () => {
+    const r = getCurrentPlayerLabel({
+      mode: "pve",
+      currentSide: "red",
+      assigned: false,
+      aiFirst: true,
+    });
+    expect(r.text).toBe("电脑");
+    expect(r.role).toBe("ai");
+  });
+
+  it("returns 玩家 in PVE when current side equals player side", () => {
+    const r = getCurrentPlayerLabel({ mode: "pve", currentSide: "red", playerSide: "red" });
+    expect(r.text).toBe("玩家");
+    expect(r.role).toBe("player");
+  });
+
+  it("returns 电脑 in PVE when current side differs from player side", () => {
+    const r = getCurrentPlayerLabel({ mode: "pve", currentSide: "blue", playerSide: "red" });
+    expect(r.text).toBe("电脑");
+    expect(r.role).toBe("ai");
+  });
+
+  it("returns 玩家1 in PVP when current side is the first side", () => {
+    const r = getCurrentPlayerLabel({
+      mode: "pvp",
+      currentSide: "red",
+      sidesOrder: ["red", "blue"],
+    });
+    expect(r.text).toBe("玩家1");
+    expect(r.role).toBe("playerN");
+  });
+
+  it("returns 玩家2 in PVP when current side is the second side", () => {
+    const r = getCurrentPlayerLabel({
+      mode: "pvp",
+      currentSide: "blue",
+      sidesOrder: ["red", "blue"],
+    });
+    expect(r.text).toBe("玩家2");
+    expect(r.role).toBe("playerN");
+  });
+
+  it("supports more than two players in PVP", () => {
+    const r = getCurrentPlayerLabel({
+      mode: "pvp",
+      currentSide: 3,
+      sidesOrder: [1, 2, 3, 4],
+    });
+    expect(r.text).toBe("玩家3");
+  });
+
+  it("returns dash in PVE when playerSide is missing and aiFirst is unknown", () => {
+    const r = getCurrentPlayerLabel({ mode: "pve", currentSide: "red" });
+    expect(r.text).toBe("—");
+  });
+});

--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -872,7 +872,9 @@ if (typeof $j !== "undefined") {
             rule.planeBack("win", $j(this).attr("type"), $j(this));
             if (rule.victory()) {
               planeAudio.playWinMusic();
-              alert(planeOption.currentUser + "用户胜利!");
+              const winnerEl = document.getElementById("current-player");
+              const winnerLabel = winnerEl ? winnerEl.textContent : planeOption.currentUser;
+              alert(winnerLabel + "胜利!");
               return;
             }
             planeAudio.playLitWinMusic();
@@ -1049,21 +1051,44 @@ if (typeof $j !== "undefined") {
   }
 
   /**
-   * Update status bar
+   * Update status bar - show the current user's role (玩家N/电脑) instead of color
+   * If multiple human players exist, distinguish them with player numbers.
    */
   function updateStatusBar() {
-    const COLOR_NAMES_BROWSER = { red: "红", blue: "蓝", yellow: "黄", green: "绿" };
     const TYPE_NAMES_BROWSER = { normal: "玩家", computer: "电脑", close: "无" };
     const current = planeOption.currentUser;
-    $j("#current-player")
-      .text(COLOR_NAMES_BROWSER[current] + "方")
-      .css("color", current);
+    // Count totals first
+    let humanTotal = 0;
+    let aiTotal = 0;
+    for (let i = 0; i < planeOption.userList.length; i++) {
+      const st = planeOption.userList[i].state;
+      if (st === "normal") humanTotal++;
+      else if (st === "computer") aiTotal++;
+    }
+    // Assign labels in userList order (stable)
+    let humanIdx = 0;
+    let aiIdx = 0;
+    let currentLabel = "玩家";
     for (let i = 0; i < planeOption.userList.length; i++) {
       const user = planeOption.userList[i];
+      let label;
+      if (user.state === "normal") {
+        humanIdx++;
+        label = humanTotal > 1 ? "玩家" + humanIdx : "玩家";
+      } else if (user.state === "computer") {
+        aiIdx++;
+        label = aiTotal > 1 ? "电脑" + aiIdx : "电脑";
+      } else {
+        label = TYPE_NAMES_BROWSER[user.state] || "";
+      }
+      if (user.color === current) {
+        currentLabel = label;
+      }
+      $j("#type-" + user.color).text(label);
       const count = $j(".plane[type=" + user.color + "][state=win]").length;
       $j("#count-" + user.color).text(count);
-      $j("#type-" + user.color).text(TYPE_NAMES_BROWSER[user.state] || "");
     }
+    $j("#current-player").text(currentLabel).css("color", current);
   }
 
   /**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,8 @@ export default [
         $j: "writable",
         SlotMachine: "readonly",
         Vue: "readonly",
+        // Shared helper from apps/common/game-utils.js (loaded via <script> in browser)
+        getCurrentPlayerLabel: "readonly",
         planeOption: "writable",
         planeAudio: "writable",
         rule: "writable",


### PR DESCRIPTION
## Summary

统一各游戏在状态栏、轮次提示，**以及游戏结束的"获胜"提示**中"当前行动方 / 获胜方"的展示，从颜色 / 角色名（红方、蓝方、龙队、虎队、猫、鱼、X、O 等）改为：

- **PVE 模式**：`玩家` / `电脑`
- **PVP 模式**：`玩家1` / `玩家2`（按先手顺序编号）
- **多人 PVP**（如跳棋、飞行棋）：`玩家1` / `玩家2` / ... 或 `电脑1` / `电脑2`

Closes #17

## 主要变更

### 新增工具函数

`apps/common/game-utils.js` 中新增 `getCurrentPlayerLabel(opts)`，根据 `mode` / `playerSide` / `sidesOrder` / `assigned` / `aiFirst` 解析得到通用标签：

```js
getCurrentPlayerLabel({
  mode: state.mode,            // 'pve' | 'pvp'
  currentSide: state.currentTeam,
  playerSide: state.playerTeam,
  sidesOrder: ['red', 'blue'], // 按先手顺序
  assigned: state.teamAssigned,// 翻棋类才会用到
  aiFirst: state.aiFirst,      // 翻棋类 PVE 翻牌前用到
});
// => { text: '玩家1', role: 'playerN' }
```

针对翻棋类游戏，PVE 模式翻牌前 `playerTeam` 还未确定时，会基于 `aiFirst` 判断是 `玩家` 还是 `电脑`，避免提前泄露颜色身份。

同一个工具函数同时用于游戏结束界面 `winner-text`，确保获胜提示也使用相同的命名风格。

### 接入的游戏（22 个 + 1 个保持不变）

- **翻棋类**：`animal-chess`、`cat-and-mouse`、`knife-kills-chicken`、`little-emperor`、`dragon-tiger-fight`、`card-game/chinese-army-chess`
  - 翻牌前 `currentTeam` 为 null 显示 `—`
  - PVE 翻牌后显示 `玩家`/`电脑`，PVP 翻牌后显示 `玩家1`/`玩家2`
  - 同步更新 "X 的回合" 提示与 "X 获胜！" 结束提示
- **棋盘类**：`tic-tac-toe`、`reversi`、`gomoku`、`go`、`chinese-chess`、`international-chess`、`board-game/chinese-army-chess`、`checkers`、`chinese-checkers`
  - 同时更新 "轮到 X 行动" 消息与游戏结束界面
- **童年棋类**：`zuan-niu-jiao-jian`、`xiao-mao-diao-yu`、`si-bu-ding`、`ma-yi-ban-jia`、`lang-chi-yang`、`bai-si-long`
  - 状态栏与结束提示一并更新（如"上方 (A) 摆出四龙获胜！"→"玩家1 摆出四龙获胜！"）
- **飞行棋**：多人独立配置时显示 `玩家`/`玩家1`/`玩家2`、`电脑`/`电脑1`/`电脑2`，胜利 alert 同样使用该标签
- `bie-mao-keng` 已经是这种实现，未改动

### 顺带的项目工程改进

- 新增 `.gitattributes` 把所有文本文件强制以 LF 存储（Windows 脚本除外），消除 Windows 编辑器和 AI 工具偶然写入 CRLF 导致 prettier 报 `Delete \r` 的问题。
- 新增 `.editorconfig` 让常见编辑器自动遵循 LF / 缩进等约定。
- 把 `getCurrentPlayerLabel` 加到 `eslint.config.js` 的 globals，避免 `no-undef`。

## 测试

- `apps/common/game-utils.test.js` 中新增 10 条单元测试覆盖 `getCurrentPlayerLabel` 各种情况
- 全量 1541 个测试通过
- 所有改动文件 diagnostics 干净
- `npm run lint` 0 errors（212 个 warning 都是项目里既有的 `no-redeclare`，与本次无关）
