### PR TITLE
Smarter AI for all 6 card games (animal-chess, cat-and-mouse, little-emperor, dragon-tiger-fight, chinese-army-chess, knife-kills-chicken)

### DIFF
--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable */
 // ============================================================
 // Animal Chess - Game Core Logic
 // ============================================================
@@ -21,6 +21,7 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   flipCard = _core.flipCard;
   moveCard = _core.moveCard;
   createBaseState = _core.createBaseState;
+  smartAiDecide = _core.smartAiDecide;
 }
 
 // All animal names (shared by red/blue, rank 1-8, lower value = higher rank)
@@ -241,76 +242,33 @@ function checkGameOver(board, currentTeam) {
 }
 
 /**
- * AI decision: select optimal action
- * Priority: capture (prefer high rank, avoid high-rank mutual destruction) > flip (random) > move (random)
+ * Piece value function for AI scoring.
+ * Stronger pieces score higher; rank 8 (rat) gets reversal premium because
+ * it can capture the opponent's rank 1 elephant.
+ * @param {number} rank
+ * @returns {number}
+ */
+function pieceValue(rank) {
+  if (rank === 1) return 10;
+  if (rank === 8) return 5;
+  return 9 - rank;
+}
+
+/**
+ * AI decision: smart one-step lookahead.
+ * Priority: capture (highest expected score) > flip (least risky) > move (escape/approach).
  * @param {GameState} state
  * @param {string} aiTeam - AI team 'red' | 'blue'
  * @returns {{type, from?, to?, x?, y?}|null}
  */
 function aiDecide(state, aiTeam) {
-  const board = state.board;
-
-  // Priority 1: capture (prefer high rank pieces, avoid high-rank mutual destruction)
-  const allCaptures = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidCaptures(board, x, y, aiTeam);
-      for (const t of targets) {
-        const target = board[t.y][t.x];
-        const mutual = isMutualDestruction(card, target);
-        allCaptures.push({
-          from: { x, y },
-          to: t,
-          defenderRank: target.rank,
-          attackerRank: card.rank,
-          mutual,
-        });
-      }
-    }
-  }
-  if (allCaptures.length > 0) {
-    // Sort: prefer non-mutual first, then lower defender rank (higher value target), then higher attacker rank (lower value attacker)
-    allCaptures.sort((a, b) => {
-      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
-      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
-      return b.attackerRank - a.attackerRank;
-    });
-    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
-  }
-
-  // Priority 2: flip (random)
-  const faceDownCells = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (card && !card.faceUp) faceDownCells.push({ x, y });
-    }
-  }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
-
-  // Priority 3: move (random)
-  const allMoves = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidMoves(board, x, y);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
-    }
-  }
-  if (allMoves.length > 0) {
-    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
-
-  return null;
+  return smartAiDecide(state, aiTeam, {
+    canCapture: canCapture,
+    isMutualDestruction: isMutualDestruction,
+    pieceValue: pieceValue,
+    getValidCaptures: getValidCaptures,
+    getValidMoves: getValidMoves,
+  });
 }
 
 // ============================================================

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable */
 // ============================================================
 // Cat Catches Mouse - Game Core Logic
 // ============================================================
@@ -21,6 +21,7 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   flipCard = _core.flipCard;
   moveCard = _core.moveCard;
   createBaseState = _core.createBaseState;
+  smartAiDecide = _core.smartAiDecide;
 }
 
 // All piece names (shared by red/blue, sorted by rank, lower value = stronger)
@@ -229,79 +230,31 @@ function checkGameOver(board, currentTeam) {
 }
 
 /**
- * AI decision: select optimal action
- * Priority:
- * 1. Capture (prefer non-mutual; then low defenderRank high-value target; then high attackerRank low-value attacker)
- * 2. Flip (random face-down card)
- * 3. Move (random legal move)
+ * Piece value for AI scoring.
+ * No reversal in this game; lower rank value (stronger piece) is more valuable.
+ * Rank range is 0..7 -> value 8..1.
+ * @param {number} rank
+ * @returns {number}
+ */
+function pieceValue(rank) {
+  return 8 - rank;
+}
+
+/**
+ * AI decision: smart one-step lookahead.
+ * Priority: capture (highest expected score) > flip (least risky) > move (escape/approach).
  * @param {GameState} state
  * @param {string} aiTeam - AI team 'red' | 'blue'
  * @returns {{type, from?, to?, x?, y?}|null}
  */
 function aiDecide(state, aiTeam) {
-  const board = state.board;
-
-  // Priority 1: capture
-  const allCaptures = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidCaptures(board, x, y, aiTeam);
-      for (const t of targets) {
-        const target = board[t.y][t.x];
-        const mutual = isMutualDestruction(card, target);
-        allCaptures.push({
-          from: { x, y },
-          to: t,
-          defenderRank: target.rank,
-          attackerRank: card.rank,
-          mutual,
-        });
-      }
-    }
-  }
-  if (allCaptures.length > 0) {
-    // Sort: prefer non-mutual, then prefer low rank (high value), then use high rank (low value attacker)
-    allCaptures.sort((a, b) => {
-      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
-      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
-      return b.attackerRank - a.attackerRank;
-    });
-    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
-  }
-
-  // Priority 2: flip (random)
-  const faceDownCells = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (card && !card.faceUp) faceDownCells.push({ x, y });
-    }
-  }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
-
-  // Priority 3: move (random)
-  const allMoves = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidMoves(board, x, y);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
-    }
-  }
-  if (allMoves.length > 0) {
-    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
-
-  return null;
+  return smartAiDecide(state, aiTeam, {
+    canCapture: canCapture,
+    isMutualDestruction: isMutualDestruction,
+    pieceValue: pieceValue,
+    getValidCaptures: getValidCaptures,
+    getValidMoves: getValidMoves,
+  });
 }
 
 // ============================================================

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable */
+/* global DIRECTIONS:writable, chooseBestCapture:writable, chooseBestFlip:writable, chooseBestMove:writable */
 // ============================================================
 // Chinese Army Chess (Flip Chess) - Game Core Logic
 // ============================================================
@@ -12,9 +12,22 @@ if (typeof judgeRPS === "undefined" && typeof require !== "undefined") {
   var judgeRPS = _gameUtils.judgeRPS;
   var shuffleArray = _gameUtils.shuffleArray;
 }
-if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
-  const _core = require("../../common/card-game-core.js");
-  DIRECTIONS = _core.DIRECTIONS;
+// Each binding is checked individually so that later requires of this module
+// (after another game.js has already populated some globals) still get the
+// game-specific helpers we need.
+if (typeof require !== "undefined") {
+  if (typeof DIRECTIONS === "undefined") {
+    DIRECTIONS = require("../../common/card-game-core.js").DIRECTIONS;
+  }
+  if (typeof chooseBestCapture === "undefined") {
+    chooseBestCapture = require("../../common/card-game-core.js").chooseBestCapture;
+  }
+  if (typeof chooseBestFlip === "undefined") {
+    chooseBestFlip = require("../../common/card-game-core.js").chooseBestFlip;
+  }
+  if (typeof chooseBestMove === "undefined") {
+    chooseBestMove = require("../../common/card-game-core.js").chooseBestMove;
+  }
 }
 
 // ============================================================
@@ -589,8 +602,61 @@ function checkGameOver(state) {
 }
 
 /**
- * AI decision: select optimal action
- * Priority: capture flag > capture (prefer high rank) > flip (random) > move (random)
+ * Whether attacker-defender combat is mutual destruction.
+ * Bombs and mines (vs non-engineer) trigger mutual destruction; equal-rank
+ * normal collisions also do.
+ * @param {Piece} attacker
+ * @param {Piece} defender
+ * @returns {boolean}
+ */
+function isMutualDestruction(attacker, defender) {
+  if (!attacker || !defender) return false;
+  if (resolveCombat(attacker, defender) === "mutual_destruction") return true;
+  return false;
+}
+
+/**
+ * Piece value used by the smart AI for scoring.
+ *
+ * Pieces are ranked by tactical impact, not strictly by military rank:
+ * - 司令(rank 1) is irreplaceable
+ * - 工兵(rank 10) gets a reversal premium because it disarms mines
+ * - 炸弹 / 地雷 carry strategic value: bombs are sacrificial high-value pieces,
+ *   mines are immobile but hard to clear
+ *
+ * Signature uses 3 args so the shared smart AI passes the full card object
+ * (1-arg form would be treated as a legacy `pieceValue(rank)` callback, which
+ * cannot distinguish bombs/mines/flags whose rank is null).
+ *
+ * @param {Piece} piece
+ * @param {Piece} _other
+ * @param {string} _role
+ * @returns {number}
+ */
+function pieceValue(piece, _other, _role) {
+  if (!piece) return 0;
+  if (isFlag(piece.name)) return 100; // flag is the win condition
+  if (isBomb(piece.name)) return 7; // bombs trade for any non-flag piece
+  if (isMine(piece.name)) return 4; // mines block lanes; only engineers can clear
+  if (!isNormalPiece(piece.name)) return 1;
+  // Normal pieces: rank 1 (司令) is most valuable, rank 10 (工兵) is mine sweeper
+  if (piece.rank === 1) return 12;
+  if (piece.rank === 10) return 6; // engineer reversal premium (vs mine)
+  return 11 - piece.rank; // rank 2..9 -> value 9..2
+}
+
+/**
+ * AI decision for chinese-army-chess.
+ *
+ * Priority:
+ *   1. Capture flag (game-winning move)
+ *   2. Capture (smart, with counter-attack lookahead)
+ *   3. Approach the (revealed) flag with our smallest normal piece - the
+ *      flag-capture candidate. If we're not next to the flag yet, walk a step
+ *      closer; this is the only path to victory in this game.
+ *   4. Flip (avoid revealing pieces near our 司令 / 军长)
+ *   5. Move (escape threats / approach prey, suicide-aware)
+ *
  * @param {GameState} state
  * @param {string} aiTeam - AI team 'red' | 'blue'
  * @returns {{type, from?, to?, x?, y?}|null}
@@ -598,7 +664,7 @@ function checkGameOver(state) {
 function aiDecide(state, aiTeam) {
   const board = state.board;
 
-  // Priority 1: capture flag (highest priority)
+  // Priority 1: capture flag (highest priority, game-winning move)
   for (let y = 0; y < 5; y++) {
     for (let x = 0; x < 5; x++) {
       const piece = board[y][x];
@@ -610,69 +676,142 @@ function aiDecide(state, aiTeam) {
     }
   }
 
-  // Priority 2: capture (prefer high rank, avoid high-rank mutual destruction)
-  const allCaptures = [];
-  for (let y = 0; y < 5; y++) {
-    for (let x = 0; x < 5; x++) {
-      const piece = board[y][x];
-      if (!piece || !piece.faceUp || piece.team !== aiTeam) continue;
-      const targets = getValidCaptures(board, x, y, aiTeam);
-      for (const t of targets) {
-        const target = board[t.y][t.x];
-        const combatResult = resolveCombat(piece, target);
-        const mutual = combatResult === "mutual_destruction";
-        allCaptures.push({
-          from: { x, y },
-          to: t,
-          defenderRank: target.rank !== null ? target.rank : 999,
-          attackerRank: piece.rank !== null ? piece.rank : 999,
-          mutual,
-        });
+  // Build deps for the shared smart helpers. The 5x5 board needs a custom
+  // inBounds; getValidMoves needs to drop flag targets so smart move scoring
+  // does not treat the (possibly unreachable) flag tile as a normal target.
+  const deps = {
+    canCapture: canCapture,
+    isMutualDestruction: isMutualDestruction,
+    pieceValue: pieceValue,
+    inBounds: inBounds,
+    getValidCaptures: function (b, x, y, team) {
+      return getValidCaptures(b, x, y, team);
+    },
+    getValidMoves: function (b, x, y) {
+      // Smart move scoring assumes empty target cells. The flag-capture branch
+      // already runs above as a preempt; here we filter out flag targets so
+      // simulateMove won't write onto the flag tile.
+      const moves = [];
+      const piece = b[y][x];
+      if (!piece || !piece.faceUp) return moves;
+      const list = getValidMoves(b, x, y, piece.team);
+      for (const t of list) {
+        if (t.type !== "capture_flag") moves.push({ x: t.x, y: t.y });
       }
-    }
-  }
+      return moves;
+    },
+  };
 
-  if (allCaptures.length > 0) {
-    // non-mutual first, then defenderRank ascending (low value = high rank), attackerRank descending (use low value piece)
-    allCaptures.sort((a, b) => {
-      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
-      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
-      return b.attackerRank - a.attackerRank;
-    });
-    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
-  }
+  // Priority 2: capture
+  const cap = chooseBestCapture(board, aiTeam, deps, 5);
+  if (cap) return cap;
 
-  // Priority 3: flip (random)
-  const faceDownCells = [];
-  for (let y = 0; y < 5; y++) {
-    for (let x = 0; x < 5; x++) {
-      const piece = board[y][x];
-      if (piece && !piece.faceUp) faceDownCells.push({ x, y });
-    }
-  }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
+  // Priority 3: approach the revealed flag with our smallest normal piece.
+  // This is the dominant winning condition in chinese-army-chess: legacy AI
+  // wins ~96% of its games via flag capture, so the smart AI must actively
+  // pursue the flag rather than just react to threats.
+  const approachFlag = approachFlagMove(board, aiTeam);
+  if (approachFlag) return approachFlag;
 
-  // Priority 4: move (random)
-  const allMoves = [];
-  for (let y = 0; y < 5; y++) {
-    for (let x = 0; x < 5; x++) {
-      const piece = board[y][x];
-      if (!piece || !piece.faceUp || piece.team !== aiTeam) continue;
-      const targets = getValidMoves(board, x, y, aiTeam);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
-    }
-  }
-  if (allMoves.length > 0) {
-    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
+  // Priority 4: flip
+  const flip = chooseBestFlip(board, aiTeam, deps, 5);
+  if (flip) return flip;
+
+  // Priority 5: move
+  const mv = chooseBestMove(board, aiTeam, deps, 5);
+  if (mv) return mv;
 
   return null;
+}
+
+/**
+ * If the flag is face-up and we have our team's smallest normal piece on the
+ * board, return a one-step move that strictly reduces the Manhattan distance
+ * between that piece and the flag. Returns null otherwise.
+ *
+ * The smallest normal piece is the only one that can capture the flag, so we
+ * actively walk it toward the flag. Among legal moves we pick the one whose
+ * resulting cell is closest to the flag; ties broken by avoiding cells that
+ * are under threat by stronger enemies.
+ *
+ * @param {Board} board
+ * @param {string} aiTeam
+ * @returns {{type:'move', from:{x,y}, to:{x,y}}|null}
+ */
+function approachFlagMove(board, aiTeam) {
+  // Find the face-up flag
+  let flagX = -1;
+  let flagY = -1;
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 5; x++) {
+      const p = board[y][x];
+      if (p && isFlag(p.name) && p.faceUp) {
+        flagX = x;
+        flagY = y;
+      }
+    }
+  }
+  if (flagX < 0) return null;
+
+  // Find our team's smallest normal piece (highest rank value)
+  const smallest = getLowestNormalPiece(board, aiTeam);
+  if (!smallest) return null;
+
+  // Locate it on the board
+  let sx = -1;
+  let sy = -1;
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 5; x++) {
+      const p = board[y][x];
+      if (p && p.faceUp && p.team === aiTeam && p.name === smallest.name) {
+        sx = x;
+        sy = y;
+      }
+    }
+  }
+  if (sx < 0) return null;
+
+  const currDist = Math.abs(sx - flagX) + Math.abs(sy - flagY);
+  // Already adjacent - the flag-capture branch above should have handled it,
+  // but keep this defensive check.
+  if (currDist <= 1) return null;
+
+  const moves = getValidMoves(board, sx, sy, aiTeam);
+  let best = null;
+  let bestDist = Infinity;
+  let bestThreatened = true;
+  for (const t of moves) {
+    if (t.type !== "move") continue;
+    const dist = Math.abs(t.x - flagX) + Math.abs(t.y - flagY);
+    if (dist >= currDist) continue; // strictly closer only
+    // Check whether the cell is currently threatened by any face-up enemy
+    // strong enough to capture the smallest piece
+    let threatened = false;
+    for (const { dx, dy } of DIRECTIONS) {
+      const nx = t.x + dx;
+      const ny = t.y + dy;
+      if (!inBounds(nx, ny)) continue;
+      const enemy = board[ny][nx];
+      if (!enemy || !enemy.faceUp || enemy.team === aiTeam) continue;
+      if (canCapture(enemy, smallest)) {
+        threatened = true;
+        break;
+      }
+    }
+    // Prefer non-threatened with shorter distance; among threatened cells,
+    // pick the closest one (still better than wandering randomly).
+    if (
+      best === null ||
+      (bestThreatened && !threatened) ||
+      (bestThreatened === threatened && dist < bestDist)
+    ) {
+      best = t;
+      bestDist = dist;
+      bestThreatened = threatened;
+    }
+  }
+  if (!best) return null;
+  return { type: "move", from: { x: sx, y: sy }, to: { x: best.x, y: best.y } };
 }
 
 // ============================================================
@@ -697,6 +836,8 @@ if (typeof module !== "undefined" && module.exports) {
     inBounds,
     canCapture,
     resolveCombat,
+    isMutualDestruction,
+    pieceValue,
     getLowestNormalPiece,
     canCaptureFlag,
     createGameState,

--- a/apps/card-game/chinese-army-chess/game.test.js
+++ b/apps/card-game/chinese-army-chess/game.test.js
@@ -464,6 +464,73 @@ describe("aiDecide - AI 决策优先级", () => {
     expect(decision).not.toBeNull();
     expect(decision.type).toBe("flip");
   });
+
+  // ----------------------------------------------------------
+  // Smart AI behaviour (one-step lookahead) tests
+  // ----------------------------------------------------------
+  it("智能 AI：吃子时避免被反吃（送子）", () => {
+    const board = emptyBoard();
+    // Red 师长 (rank 3) at (1,1) can capture blue 排长 (rank 8) at (1,2),
+    // but after the move (1,2) is adjacent to blue 司令 (rank 1) at (1,3) which captures it.
+    // Red 营长 (rank 6) at (3,3) can capture blue 班长 (rank 9) at (3,2) safely.
+    // AI should prefer the safe capture rather than sending its 师长 to die.
+    board[1][1] = makePiece("师长", "red"); // rank 3
+    board[1][2] = makePiece("排长", "blue"); // rank 8 (target)
+    board[1][3] = makePiece("司令", "blue"); // rank 1 (counter-threat)
+    board[3][3] = makePiece("营长", "red"); // rank 6
+    board[3][2] = makePiece("班长", "blue"); // rank 9 (safe target)
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision.type).toBe("capture");
+    expect(decision.from).toEqual({ x: 3, y: 3 });
+    expect(decision.to).toEqual({ x: 2, y: 3 });
+  });
+
+  it("智能 AI：抱军旗优先级高于普通吃子", () => {
+    const board = emptyBoard();
+    // Red 工兵 adjacent to face-up flag (capture-flag is the win condition)
+    board[2][2] = makePiece("工兵", "red");
+    board[2][3] = { name: "军旗", team: "neutral", rank: null, faceUp: true };
+    // Also a normal capture available
+    board[0][0] = makePiece("司令", "red");
+    board[0][1] = makePiece("工兵", "blue");
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision.type).toBe("move");
+    expect(decision.to).toEqual({ x: 3, y: 2 });
+  });
+
+  it("智能 AI：被威胁时走子选择逃离", () => {
+    const board = emptyBoard();
+    // Red 班长 (rank 9) at (1,1) threatened by blue 师长 (rank 3) at (1,2).
+    // (0,1), (1,0), (2,1) are empty; (2,1) is the threatened square if moved sideways.
+    // Should pick a move that escapes the threat.
+    board[1][1] = makePiece("班长", "red");
+    board[1][2] = makePiece("师长", "blue");
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision.type).toBe("move");
+    expect(decision.from).toEqual({ x: 1, y: 1 });
+    // The new cell should not be threatened by (1,2)
+    const newCell = decision.to;
+    const adjacent =
+      Math.abs(newCell.x - 1) + Math.abs(newCell.y - 2) === 1 &&
+      !(newCell.x === 1 && newCell.y === 1);
+    // Walking to (2,1) keeps us adjacent to (1,2) -> still threatened.
+    // Walking to (0,1) or (1,0) escapes.
+    if (adjacent) {
+      // direct neighbour to attacker -> still threatened, should not happen
+      expect.fail("AI walked into threat at " + JSON.stringify(newCell));
+    }
+  });
+
+  it("智能 AI：无可选项时返回 null", () => {
+    const board = emptyBoard();
+    // Just an empty board -> no legal actions
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision).toBeNull();
+  });
 });
 
 // ============================================================

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, smartAiDecide:writable */
 // ============================================================
 // Dragon Tiger Fight - Game Core Logic
 // ============================================================
@@ -17,6 +17,7 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   DIRECTIONS = _core.DIRECTIONS;
   inBounds = _core.inBounds;
   getValidMoves = _core.getValidMoves;
+  smartAiDecide = _core.smartAiDecide;
 }
 
 // Dragon team 8 pieces (rank 1-8, lower value = higher rank)
@@ -361,76 +362,35 @@ function checkGameOver(board, currentTeam) {
 }
 
 /**
- * AI decision: select optimal action
- * Priority: capture (prefer high rank) > flip (random) > move (random)
+ * Piece value for AI scoring.
+ * Stronger pieces score higher; rank 8 (transformer dragon / king of small tigers)
+ * gets reversal premium because it can capture rank 1.
+ * @param {number} rank
+ * @returns {number}
+ */
+function pieceValue(rank) {
+  if (rank === 1) return 10;
+  if (rank === 8) return 5;
+  return 9 - rank;
+}
+
+/**
+ * AI decision: smart one-step lookahead.
+ * Priority: capture (highest expected score) > flip (least risky) > move (escape/approach).
  * @param {GameState} state
  * @param {string} aiTeam - AI team 'dragon' | 'tiger'
  * @returns {{type, from?, to?, x?, y?}|null}
  */
 function aiDecide(state, aiTeam) {
-  const board = state.board;
-
-  // Priority 1: capture (prefer high rank pieces, avoid high-rank mutual destruction)
-  const allCaptures = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidCaptures(board, x, y, aiTeam);
-      for (const t of targets) {
-        const target = board[t.y][t.x];
-        const mutual = isMutualDestruction(card, target);
-        allCaptures.push({
-          from: { x, y },
-          to: t,
-          defenderRank: target.rank,
-          attackerRank: card.rank,
-          mutual,
-        });
-      }
-    }
-  }
-  if (allCaptures.length > 0) {
-    // Sort: prefer non-mutual, then lower defender rank (higher value target), then higher attacker rank (lower value attacker)
-    allCaptures.sort((a, b) => {
-      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1; // non-mutual first
-      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank; // lower rank = higher value target
-      return b.attackerRank - a.attackerRank; // use lower-value attacker
-    });
-    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
-  }
-
-  // Priority 2: flip (random)
-  const faceDownCells = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (card && !card.faceUp) faceDownCells.push({ x, y });
-    }
-  }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
-
-  // Priority 3: move (random)
-  const allMoves = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidMoves(board, x, y);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
-    }
-  }
-  if (allMoves.length > 0) {
-    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
-
-  return null;
+  return smartAiDecide(state, aiTeam, {
+    canCapture: canCapture,
+    isMutualDestruction: isMutualDestruction,
+    pieceValue: pieceValue,
+    getValidCaptures: function (board, x, y, team) {
+      return getValidCaptures(board, x, y, team);
+    },
+    getValidMoves: getValidMoves,
+  });
 }
 
 // ============================================================

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, flipCard:writable, moveCard:writable, createBaseState:writable */
+/* global DIRECTIONS:writable, inBounds:writable, flipCard:writable, moveCard:writable, createBaseState:writable, chooseBestCapture:writable, chooseBestFlip:writable, chooseBestMove:writable */
 // ============================================================
 // Knife Kills Chicken (Carry Weapon Version) - Game Core Logic
 // ============================================================
@@ -12,13 +12,19 @@ if (typeof judgeRPS === "undefined" && typeof require !== "undefined") {
   var judgeRPS = _gameUtils.judgeRPS;
   var shuffleArray = _gameUtils.shuffleArray;
 }
-if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
+// Each binding is checked individually so that later requires of this module
+// (after another game.js has already populated some globals) still get the
+// game-specific helpers we need.
+if (typeof require !== "undefined") {
   const _core = require("../../common/card-game-core.js");
-  DIRECTIONS = _core.DIRECTIONS;
-  inBounds = _core.inBounds;
-  flipCard = _core.flipCard;
-  moveCard = _core.moveCard;
-  createBaseState = _core.createBaseState;
+  if (typeof DIRECTIONS === "undefined") DIRECTIONS = _core.DIRECTIONS;
+  if (typeof inBounds === "undefined") inBounds = _core.inBounds;
+  if (typeof flipCard === "undefined") flipCard = _core.flipCard;
+  if (typeof moveCard === "undefined") moveCard = _core.moveCard;
+  if (typeof createBaseState === "undefined") createBaseState = _core.createBaseState;
+  if (typeof chooseBestCapture === "undefined") chooseBestCapture = _core.chooseBestCapture;
+  if (typeof chooseBestFlip === "undefined") chooseBestFlip = _core.chooseBestFlip;
+  if (typeof chooseBestMove === "undefined") chooseBestMove = _core.chooseBestMove;
 }
 
 // 8 roles
@@ -364,82 +370,173 @@ function checkGameOver(board, currentTeam) {
 }
 
 /**
- * AI selects optimal action
+ * Whether attacker-defender combat is mutual destruction.
+ * Only the rocket triggers mutual destruction in this game (it always blows up).
+ * @param {Card} attacker
+ * @param {Card} defender
+ * @returns {boolean}
+ */
+function isMutualDestruction(attacker, defender) {
+  // Rocket sacrifices itself when it captures
+  return attacker && attacker.role === "火箭" && defender;
+}
+
+/**
+ * Piece value for AI scoring. Considers carry-weapon upgrades.
+ *
+ * Base scores reflect a unit's offensive reach in this game's cyclic
+ * dominance graph (rocket is the strongest tactical asset; chicken / human
+ * are mid-tier; tools alone are inert).
+ *
+ * Signature uses 3 args so the shared smart AI passes the full card object
+ * (1-arg form would be treated as a legacy `pieceValue(rank)` callback).
+ *
+ * @param {Card} card
+ * @param {Card} _other
+ * @param {string} _role
+ * @returns {number}
+ */
+function pieceValue(card, _other, _role) {
+  if (!card) return 0;
+  switch (card.role) {
+    case "火箭":
+      return 12; // most decisive piece
+    case "鸡":
+      return 7; // beats wasp + base for knife synergy
+    case "马蜂":
+      return 6; // beats scaly
+    case "老虎":
+      return 6; // beats human
+    case "人":
+      // Carrying knife unlocks attacking chicken -> upgrade
+      return card.carrying === "刀" ? 8 : 5;
+    case "癞痢":
+      // Carrying spear unlocks attacking tiger -> upgrade
+      return card.carrying === "枪" ? 8 : 4;
+    case "刀":
+    case "枪":
+      // Standalone weapons cannot move or attack -> low intrinsic value,
+      // but high "potential" once an ally walks over.
+      return 3;
+    default:
+      return 1;
+  }
+}
+
+/**
+ * AI decision: smart one-step lookahead.
+ *
+ * Priority (matches original AI but with smarter scoring at every step):
+ *   1. capture - best score, counter-attack risk aware
+ *   2. carry weapon - human/scalper grabs own knife/spear if it unlocks new captures
+ *   3. flip - face-down cell that minimises risk
+ *   4. move - escape threats, approach prey
+ *
  * @param {GameState} state - current game state
  * @param {string} aiTeam - AI team
- * @returns {{type: string, from?: {x: number, y: number}, to?: {x: number, y: number}, x?: number, y?: number}|null} AI decision result
+ * @returns {{type: string, from?, to?, x?, y?}|null}
  */
 function aiDecide(state, aiTeam) {
   const board = state.board;
+  const deps = {
+    canCapture: canCapture,
+    isMutualDestruction: isMutualDestruction,
+    pieceValue: pieceValue,
+    getValidCaptures: function (b, x, y, team) {
+      return getValidCaptures(b, x, y, team);
+    },
+    getValidMoves: function (b, x, y) {
+      return getValidMoves(b, x, y);
+    },
+  };
 
-  // Priority 1: when capture opportunity exists, prioritize capture
-  const allCaptures = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidCaptures(board, x, y, aiTeam);
-      for (const t of targets) {
-        allCaptures.push({ from: { x, y }, to: t });
-      }
-    }
-  }
-  if (allCaptures.length > 0) {
-    const pick = allCaptures[Math.floor(Math.random() * allCaptures.length)];
-    return { type: "capture", from: pick.from, to: pick.to };
-  }
+  // Priority 1: capture
+  const cap = chooseBestCapture(board, aiTeam, deps);
+  if (cap) return cap;
 
-  // Priority 2: human/scalper adjacent to own knife/spear -> carry weapon
-  const allCarries = [];
+  // Priority 2: carry weapon (rank by upgrade value gain)
+  const carryPick = pickBestCarry(board, aiTeam);
+  if (carryPick) return carryPick;
+
+  // Priority 3: flip
+  const flip = chooseBestFlip(board, aiTeam, deps);
+  if (flip) return flip;
+
+  // Priority 4: move
+  const mv = chooseBestMove(board, aiTeam, deps);
+  if (mv) return mv;
+
+  return null;
+}
+
+/**
+ * Pick the best carry-weapon move. Prefers carriers that are NOT already at
+ * risk and prefers picking up the weapon that unlocks the most useful capture
+ * next turn (knife on a chicken-rich board, spear on a tiger-rich board).
+ * @param {(Card|null)[][]} board
+ * @param {string} aiTeam
+ * @returns {{type: 'carry', from: {x,y}, to: {x,y}}|null}
+ */
+function pickBestCarry(board, aiTeam) {
+  const candidates = [];
   for (let y = 0; y < 4; y++) {
     for (let x = 0; x < 4; x++) {
       const card = board[y][x];
       if (!card || !card.faceUp || card.team !== aiTeam) continue;
       const targets = getCarryTargets(board, x, y, aiTeam);
       for (const t of targets) {
-        allCarries.push({ from: { x, y }, to: t });
+        candidates.push({ from: { x, y }, to: t, carrier: card });
       }
     }
   }
-  if (allCarries.length > 0) {
-    const pick = allCarries[Math.floor(Math.random() * allCarries.length)];
-    return { type: "carry", from: pick.from, to: pick.to };
-  }
+  if (candidates.length === 0) return null;
 
-  // Priority 3: when face-down cards exist, flip one randomly
-  const faceDownCells = [];
+  // Score each candidate
+  for (const c of candidates) {
+    // Synergy reward: count visible enemies the upgrade would unlock
+    let unlockBonus = 0;
+    if (c.carrier.role === "人") {
+      // Human + knife -> can hunt chicken
+      unlockBonus = countVisibleEnemyRole(board, aiTeam, "鸡") * 2;
+    } else if (c.carrier.role === "癞痢") {
+      // Scalper + spear -> can hunt tiger
+      unlockBonus = countVisibleEnemyRole(board, aiTeam, "老虎") * 2;
+    }
+    // Penalty if carrier is currently safe but the destination is threatened
+    const futureBoard = [];
+    for (let y = 0; y < 4; y++) futureBoard.push(board[y].slice());
+    futureBoard[c.to.y][c.to.x] = c.carrier;
+    futureBoard[c.from.y][c.from.x] = null;
+    const futureThreatened = isThreatened(futureBoard, c.to.x, c.to.y, aiTeam);
+    c.score = unlockBonus + (futureThreatened ? -3 : 0);
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  return { type: "carry", from: candidates[0].from, to: candidates[0].to };
+}
+
+function countVisibleEnemyRole(board, aiTeam, role) {
+  let n = 0;
   for (let y = 0; y < 4; y++) {
     for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (card && !card.faceUp) {
-        faceDownCells.push({ x, y });
-      }
+      const c = board[y][x];
+      if (c && c.faceUp && c.team !== aiTeam && c.role === role) n++;
     }
   }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
+  return n;
+}
 
-  // Priority 4: randomly select own piece and move to legal position
-  const allMoves = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidMoves(board, x, y);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
-    }
+function isThreatened(board, x, y, ownTeam) {
+  const me = board[y][x];
+  if (!me || !me.faceUp) return false;
+  for (const { dx, dy } of DIRECTIONS) {
+    const nx = x + dx;
+    const ny = y + dy;
+    if (!inBounds(nx, ny)) continue;
+    const enemy = board[ny][nx];
+    if (!enemy || !enemy.faceUp || enemy.team === ownTeam) continue;
+    if (canCapture(enemy, me)) return true;
   }
-  if (allMoves.length > 0) {
-    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
-
-  // No legal actions
-  return null;
+  return false;
 }
 
 // Export for testing
@@ -451,6 +548,8 @@ if (typeof module !== "undefined" && module.exports) {
     getImagePath,
     judgeRPS,
     canCapture,
+    isMutualDestruction,
+    pieceValue,
     createGameState,
     getValidMoves,
     getValidCaptures,

--- a/apps/card-game/knife-kills-chicken/game.test.js
+++ b/apps/card-game/knife-kills-chicken/game.test.js
@@ -1340,3 +1340,74 @@ describe("aiDecide - AI决策函数", () => {
     expect(decision.type).toBe("flip");
   });
 });
+// ============================================================
+// Smart AI behaviour (one-step lookahead) tests
+// ============================================================
+describe("aiDecide - 智能 AI 行为", () => {
+  it("吃子时避免被反吃（送子）", () => {
+    // Red wasp(马蜂) at (1,1) can capture blue 癞痢 at (1,2),
+    // but adjacent (1,3) holds a blue chicken which dominates wasp -> wasp dies next turn (net -2).
+    // Red chicken at (3,3) can capture blue wasp at (3,2) safely (no adjacent threat) -> net +6.
+    // Smart AI should pick the safe chicken capture.
+    const board = emptyBoard();
+    board[1][1] = makeCard("马蜂", "red");
+    board[1][2] = makeCard("癞痢", "blue");
+    board[1][3] = makeCard("鸡", "blue"); // counter-threat: chicken beats wasp
+    board[3][3] = makeCard("鸡", "red");
+    board[3][2] = makeCard("马蜂", "blue");
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision.type).toBe("capture");
+    // Should NOT pick the wasp capture (it would die next turn)
+    expect(decision.from).toEqual({ x: 3, y: 3 });
+    expect(decision.to).toEqual({ x: 2, y: 3 });
+  });
+
+  it("无吃子机会时优先扛刀以解锁杀鸡能力", () => {
+    // Red has a human and a knife adjacent + a visible blue chicken on board.
+    // The smart carry priority should pick this carry move.
+    const board = emptyBoard();
+    board[1][1] = makeCard("人", "red");
+    board[1][2] = makeCard("刀", "red");
+    board[3][3] = makeCard("鸡", "blue");
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision.type).toBe("carry");
+    expect(decision.from).toEqual({ x: 1, y: 1 });
+    expect(decision.to).toEqual({ x: 2, y: 1 });
+  });
+
+  it("被威胁时走子选择逃离", () => {
+    // Red chicken at (1,1) threatened by blue rocket at (2,1).
+    // Smart AI should pick a move that escapes the rocket's threat zone.
+    // Legal moves: (0,1), (1,0), (1,2). All three are non-threatened cells
+    // (the rocket only threatens its 4 immediate neighbours).
+    const board = emptyBoard();
+    board[1][1] = makeCard("鸡", "red");
+    board[1][2] = makeCard("火箭", "blue");
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision.type).toBe("move");
+    expect(decision.from).toEqual({ x: 1, y: 1 });
+    // Result should be one of (0,1), (1,0), (1,2); none are adjacent to the rocket.
+    const safeTargets = [
+      JSON.stringify({ x: 0, y: 1 }),
+      JSON.stringify({ x: 1, y: 0 }),
+      JSON.stringify({ x: 1, y: 2 }),
+    ];
+    expect(safeTargets).toContain(JSON.stringify(decision.to));
+  });
+
+  it("无任何合法操作时返回 null", () => {
+    const board = emptyBoard();
+    // Red knife (cannot move/capture) surrounded by blue pieces, no face-down cards.
+    board[1][1] = makeCard("刀", "red");
+    board[1][0] = makeCard("马蜂", "blue");
+    board[1][2] = makeCard("枪", "blue");
+    board[0][1] = makeCard("老虎", "blue");
+    board[2][1] = makeCard("人", "blue");
+    const state = makeState(board, "red");
+    const decision = aiDecide(state, "red");
+    expect(decision).toBeNull();
+  });
+});

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable */
 // ============================================================
 // Little Emperor - Game Core Logic
 // ============================================================
@@ -21,6 +21,7 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   flipCard = _core.flipCard;
   moveCard = _core.moveCard;
   createBaseState = _core.createBaseState;
+  smartAiDecide = _core.smartAiDecide;
 }
 
 // All piece names (sorted by rank, rank 1-8)
@@ -235,76 +236,33 @@ function checkGameOver(board, currentTeam) {
 }
 
 /**
- * AI decision: select optimal action
- * Priority: capture (prefer high rank, avoid mutual destruction) > flip (random) > move (random)
+ * Piece value for AI scoring.
+ * Stronger pieces score higher; emperor (rank 8) gets reversal premium because
+ * it can capture grandpa (rank 1).
+ * @param {number} rank
+ * @returns {number}
+ */
+function pieceValue(rank) {
+  if (rank === 1) return 10;
+  if (rank === 8) return 5;
+  return 9 - rank;
+}
+
+/**
+ * AI decision: smart one-step lookahead.
+ * Priority: capture (highest expected score) > flip (least risky) > move (escape/approach).
  * @param {Object} state - Game state
  * @param {string} aiTeam - AI team 'red' | 'blue'
  * @returns {{type, from?, to?, x?, y?}|null}
  */
 function aiDecide(state, aiTeam) {
-  const board = state.board;
-
-  // Priority 1: capture (prefer high rank pieces, avoid high-rank mutual destruction)
-  const allCaptures = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidCaptures(board, x, y, aiTeam);
-      for (const t of targets) {
-        const target = board[t.y][t.x];
-        const mutual = isMutualDestruction(card, target);
-        allCaptures.push({
-          from: { x, y },
-          to: t,
-          defenderRank: target.rank,
-          attackerRank: card.rank,
-          mutual,
-        });
-      }
-    }
-  }
-  if (allCaptures.length > 0) {
-    // Sort: prefer non-mutual, then prefer high rank (low value), then prefer low rank attacker (high value)
-    allCaptures.sort((a, b) => {
-      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
-      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
-      return b.attackerRank - a.attackerRank;
-    });
-    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
-  }
-
-  // Priority 2: flip (random face-down card)
-  const faceDownCells = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (card && !card.faceUp) faceDownCells.push({ x, y });
-    }
-  }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
-
-  // Priority 3: move (random legal move)
-  const allMoves = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
-      const card = board[y][x];
-      if (!card || !card.faceUp || card.team !== aiTeam) continue;
-      const targets = getValidMoves(board, x, y);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
-    }
-  }
-  if (allMoves.length > 0) {
-    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
-
-  return null;
+  return smartAiDecide(state, aiTeam, {
+    canCapture: canCapture,
+    isMutualDestruction: isMutualDestruction,
+    pieceValue: pieceValue,
+    getValidCaptures: getValidCaptures,
+    getValidMoves: getValidMoves,
+  });
 }
 
 // ============================================================

--- a/apps/common/card-game-core.js
+++ b/apps/common/card-game-core.js
@@ -135,6 +135,267 @@ function moveCard(state, from, to) {
   return state;
 }
 
+// ============================================================
+// AI helper utilities (shared one-step lookahead heuristics)
+// ============================================================
+
+/**
+ * Check if the face-up piece at (x, y) is under threat:
+ * any adjacent face-up enemy can capture it via canCaptureFn.
+ * @param {Array} board
+ * @param {number} x
+ * @param {number} y
+ * @param {string} ownTeam - team of the piece at (x, y)
+ * @param {Function} canCaptureFn - (attacker, defender) => boolean
+ * @returns {boolean}
+ */
+function isPositionUnderThreat(board, x, y, ownTeam, canCaptureFn) {
+  const card = board[y][x];
+  if (!card || !card.faceUp) return false;
+  for (let i = 0; i < DIRECTIONS.length; i++) {
+    const nx = x + DIRECTIONS[i].dx;
+    const ny = y + DIRECTIONS[i].dy;
+    if (!inBounds(nx, ny)) continue;
+    const enemy = board[ny][nx];
+    if (!enemy || !enemy.faceUp || enemy.team === ownTeam) continue;
+    if (canCaptureFn(enemy, card)) return true;
+  }
+  return false;
+}
+
+/**
+ * Simulate a move: returns a shallow-cloned board with the move applied.
+ * Original board is not mutated. Cards themselves are not deep-copied (they are
+ * read-only for the simulation purposes used here).
+ * @param {Array} board
+ * @param {{x,y}} from
+ * @param {{x,y}} to
+ * @returns {Array}
+ */
+function simulateMove(board, from, to) {
+  const newBoard = new Array(4);
+  for (let y = 0; y < 4; y++) newBoard[y] = board[y].slice();
+  newBoard[to.y][to.x] = newBoard[from.y][from.x];
+  newBoard[from.y][from.x] = null;
+  return newBoard;
+}
+
+/**
+ * Simulate a capture: returns a shallow-cloned board with capture applied.
+ * - Mutual destruction: both squares cleared.
+ * - Otherwise: attacker moves into defender's square.
+ * @param {Array} board
+ * @param {{x,y}} from - attacker
+ * @param {{x,y}} to - defender
+ * @param {boolean} mutual - whether mutual destruction
+ * @returns {Array}
+ */
+function simulateCapture(board, from, to, mutual) {
+  const newBoard = new Array(4);
+  for (let y = 0; y < 4; y++) newBoard[y] = board[y].slice();
+  if (mutual) {
+    newBoard[from.y][from.x] = null;
+    newBoard[to.y][to.x] = null;
+  } else {
+    newBoard[to.y][to.x] = newBoard[from.y][from.x];
+    newBoard[from.y][from.x] = null;
+  }
+  return newBoard;
+}
+
+/**
+ * Smart AI decision with one-step lookahead heuristics.
+ *
+ * Action priority (kept compatible with original greedy AI):
+ *   1. capture - choose the highest-scoring capture (counter-attack risk aware)
+ *   2. flip    - choose a face-down cell that is least risky to flip
+ *   3. move    - choose a move that escapes/avoids threats and approaches prey
+ *
+ * @param {Object} state - game state with board/currentTeam etc.
+ * @param {string} aiTeam - team controlled by AI
+ * @param {Object} deps - game-specific dependencies
+ * @param {Function} deps.canCapture - (attacker, defender) => boolean
+ * @param {Function} deps.isMutualDestruction - (attacker, defender) => boolean
+ * @param {Function} deps.pieceValue - (rank) => number (higher = more valuable)
+ * @param {Function} deps.getValidCaptures - (board, x, y, team) => Array<{x,y}>
+ * @param {Function} deps.getValidMoves - (board, x, y) => Array<{x,y}>
+ * @returns {{type, from?, to?, x?, y?}|null}
+ */
+function smartAiDecide(state, aiTeam, deps) {
+  const board = state.board;
+  const { canCapture, isMutualDestruction, pieceValue, getValidCaptures, getValidMoves } = deps;
+
+  // Priority 1: capture (one-step lookahead for counter-attack risk)
+  const allCaptures = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getValidCaptures(board, x, y, aiTeam);
+      for (let k = 0; k < targets.length; k++) {
+        const t = targets[k];
+        const target = board[t.y][t.x];
+        const mutual = isMutualDestruction(card, target);
+        const attVal = pieceValue(card.rank);
+        const defVal = pieceValue(target.rank);
+        let score;
+        if (mutual) {
+          // Mutual destruction: net = enemy loss - own loss
+          score = defVal - attVal;
+        } else {
+          // Normal capture: simulate and check if attacker would be captured next turn
+          const futureBoard = simulateCapture(board, { x, y }, t, false);
+          const exposed = isPositionUnderThreat(futureBoard, t.x, t.y, aiTeam, canCapture);
+          score = defVal - (exposed ? attVal : 0);
+        }
+        allCaptures.push({
+          from: { x, y },
+          to: t,
+          score,
+          defenderRank: target.rank,
+          attackerRank: card.rank,
+          mutual,
+        });
+      }
+    }
+  }
+  if (allCaptures.length > 0) {
+    allCaptures.sort((a, b) => {
+      // Primary: highest expected score
+      if (a.score !== b.score) return b.score - a.score;
+      // Tiebreakers preserve legacy behavior:
+      //  prefer non-mutual, lower defender rank (higher value),
+      //  higher attacker rank (preserve high-value attackers)
+      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
+      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
+      return b.attackerRank - a.attackerRank;
+    });
+    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
+  }
+
+  // Priority 2: flip (avoid flipping next to own face-up pieces)
+  const faceDownCells = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (card && !card.faceUp) faceDownCells.push({ x, y });
+    }
+  }
+  if (faceDownCells.length > 0) {
+    // Find own piece values at risk (most valuable own piece adjacent to flip)
+    const scored = faceDownCells.map((pos) => {
+      let maxAdjOwnVal = 0;
+      let adjEnemyCount = 0;
+      for (let i = 0; i < DIRECTIONS.length; i++) {
+        const nx = pos.x + DIRECTIONS[i].dx;
+        const ny = pos.y + DIRECTIONS[i].dy;
+        if (!inBounds(nx, ny)) continue;
+        const c = board[ny][nx];
+        if (!c || !c.faceUp) continue;
+        if (c.team === aiTeam) {
+          const v = pieceValue(c.rank);
+          if (v > maxAdjOwnVal) maxAdjOwnVal = v;
+        } else {
+          adjEnemyCount++;
+        }
+      }
+      // Penalty: risk of flipping enemy that captures adjacent own piece
+      // Bonus: adjacent enemies (newly flipped own piece could threaten them)
+      // Slight bias toward the centre for strategic flexibility
+      const distFromCenter = Math.abs(pos.x - 1.5) + Math.abs(pos.y - 1.5);
+      const score = adjEnemyCount * 0.5 - maxAdjOwnVal * 1.0 - distFromCenter * 0.1;
+      return { pos, score };
+    });
+    scored.sort((a, b) => b.score - a.score);
+    const topScore = scored[0].score;
+    const top = scored.filter((s) => s.score === topScore);
+    const pick = top[Math.floor(Math.random() * top.length)].pos;
+    return { type: "flip", x: pick.x, y: pick.y };
+  }
+
+  // Priority 3: move (escape threats, approach prey, avoid suicide)
+  const allMoves = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getValidMoves(board, x, y);
+      for (let k = 0; k < targets.length; k++) {
+        const t = targets[k];
+        const cardVal = pieceValue(card.rank);
+        let score = 0;
+
+        const currThreatened = isPositionUnderThreat(board, x, y, aiTeam, canCapture);
+        const futureBoard = simulateMove(board, { x, y }, t);
+        const futureThreatened = isPositionUnderThreat(futureBoard, t.x, t.y, aiTeam, canCapture);
+
+        if (currThreatened && !futureThreatened) {
+          // Escaping danger
+          score += cardVal;
+        } else if (!currThreatened && futureThreatened) {
+          // Walking into danger (suicide) - heavy penalty
+          score -= cardVal * 1.5;
+        } else if (currThreatened && futureThreatened) {
+          // Still in danger
+          score -= cardVal * 0.5;
+        }
+
+        // Reward approaching a capturable enemy (sets up next-turn capture)
+        let approachBonus = 0;
+        for (let i = 0; i < DIRECTIONS.length; i++) {
+          const nx = t.x + DIRECTIONS[i].dx;
+          const ny = t.y + DIRECTIONS[i].dy;
+          if (!inBounds(nx, ny)) continue;
+          const enemy = futureBoard[ny][nx];
+          if (!enemy || !enemy.faceUp || enemy.team === aiTeam) continue;
+          if (canCapture(card, enemy)) {
+            const ev = pieceValue(enemy.rank);
+            if (ev > approachBonus) approachBonus = ev;
+          }
+        }
+        score += approachBonus * 0.5;
+
+        // Slight preference for advancing toward enemy face-up pieces
+        // (encourages activity rather than wandering aimlessly)
+        const enemyDistDelta = nearestEnemyDelta(board, x, y, t, aiTeam);
+        score += enemyDistDelta * 0.05;
+
+        allMoves.push({ from: { x, y }, to: t, score });
+      }
+    }
+  }
+  if (allMoves.length > 0) {
+    allMoves.sort((a, b) => b.score - a.score);
+    const topScore = allMoves[0].score;
+    const top = allMoves.filter((m) => m.score === topScore);
+    const pick = top[Math.floor(Math.random() * top.length)];
+    return { type: "move", from: pick.from, to: pick.to };
+  }
+
+  return null;
+}
+
+/**
+ * Manhattan-distance reduction toward the nearest enemy face-up piece.
+ * Positive = moving closer, negative = moving away, 0 = no enemy or unchanged.
+ */
+function nearestEnemyDelta(board, fromX, fromY, to, ownTeam) {
+  let bestBefore = Infinity;
+  let bestAfter = Infinity;
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const c = board[y][x];
+      if (!c || !c.faceUp || c.team === ownTeam) continue;
+      const dBefore = Math.abs(x - fromX) + Math.abs(y - fromY);
+      const dAfter = Math.abs(x - to.x) + Math.abs(y - to.y);
+      if (dBefore < bestBefore) bestBefore = dBefore;
+      if (dAfter < bestAfter) bestAfter = dAfter;
+    }
+  }
+  if (!isFinite(bestBefore) || !isFinite(bestAfter)) return 0;
+  return bestBefore - bestAfter;
+}
+
 /**
  * Create base game state object for red/blue card games
  * @param {string} mode - 'pvp' | 'pve'
@@ -172,5 +433,9 @@ if (typeof module !== "undefined" && module.exports) {
     flipCard: flipCard,
     moveCard: moveCard,
     createBaseState: createBaseState,
+    isPositionUnderThreat: isPositionUnderThreat,
+    simulateMove: simulateMove,
+    simulateCapture: simulateCapture,
+    smartAiDecide: smartAiDecide,
   };
 }

--- a/apps/common/card-game-core.js
+++ b/apps/common/card-game-core.js
@@ -140,6 +140,24 @@ function moveCard(state, from, to) {
 // ============================================================
 
 /**
+ * Resolve board size from a board argument. The default 4x4 inBounds works for
+ * most card games here; a 5x5 game (e.g. chinese-army-chess) supplies its own
+ * inBoundsFn so this helper falls back to the board's own dimensions.
+ * @param {Array} board
+ * @returns {{size: number, inBounds: Function}}
+ */
+function _boardDims(board, customInBounds) {
+  const size = board.length;
+  const ib =
+    typeof customInBounds === "function"
+      ? customInBounds
+      : function (x, y) {
+          return x >= 0 && x < size && y >= 0 && y < size;
+        };
+  return { size: size, inBounds: ib };
+}
+
+/**
  * Check if the face-up piece at (x, y) is under threat:
  * any adjacent face-up enemy can capture it via canCaptureFn.
  * @param {Array} board
@@ -147,15 +165,17 @@ function moveCard(state, from, to) {
  * @param {number} y
  * @param {string} ownTeam - team of the piece at (x, y)
  * @param {Function} canCaptureFn - (attacker, defender) => boolean
+ * @param {Function} [inBoundsFn] - optional per-game inBounds (defaults to board size)
  * @returns {boolean}
  */
-function isPositionUnderThreat(board, x, y, ownTeam, canCaptureFn) {
+function isPositionUnderThreat(board, x, y, ownTeam, canCaptureFn, inBoundsFn) {
   const card = board[y][x];
   if (!card || !card.faceUp) return false;
+  const dims = _boardDims(board, inBoundsFn);
   for (let i = 0; i < DIRECTIONS.length; i++) {
     const nx = x + DIRECTIONS[i].dx;
     const ny = y + DIRECTIONS[i].dy;
-    if (!inBounds(nx, ny)) continue;
+    if (!dims.inBounds(nx, ny)) continue;
     const enemy = board[ny][nx];
     if (!enemy || !enemy.faceUp || enemy.team === ownTeam) continue;
     if (canCaptureFn(enemy, card)) return true;
@@ -173,8 +193,9 @@ function isPositionUnderThreat(board, x, y, ownTeam, canCaptureFn) {
  * @returns {Array}
  */
 function simulateMove(board, from, to) {
-  const newBoard = new Array(4);
-  for (let y = 0; y < 4; y++) newBoard[y] = board[y].slice();
+  const size = board.length;
+  const newBoard = new Array(size);
+  for (let y = 0; y < size; y++) newBoard[y] = board[y].slice();
   newBoard[to.y][to.x] = newBoard[from.y][from.x];
   newBoard[from.y][from.x] = null;
   return newBoard;
@@ -191,8 +212,9 @@ function simulateMove(board, from, to) {
  * @returns {Array}
  */
 function simulateCapture(board, from, to, mutual) {
-  const newBoard = new Array(4);
-  for (let y = 0; y < 4; y++) newBoard[y] = board[y].slice();
+  const size = board.length;
+  const newBoard = new Array(size);
+  for (let y = 0; y < size; y++) newBoard[y] = board[y].slice();
   if (mutual) {
     newBoard[from.y][from.x] = null;
     newBoard[to.y][to.x] = null;
@@ -204,31 +226,20 @@ function simulateCapture(board, from, to, mutual) {
 }
 
 /**
- * Smart AI decision with one-step lookahead heuristics.
- *
- * Action priority (kept compatible with original greedy AI):
- *   1. capture - choose the highest-scoring capture (counter-attack risk aware)
- *   2. flip    - choose a face-down cell that is least risky to flip
- *   3. move    - choose a move that escapes/avoids threats and approaches prey
- *
- * @param {Object} state - game state with board/currentTeam etc.
- * @param {string} aiTeam - team controlled by AI
- * @param {Object} deps - game-specific dependencies
- * @param {Function} deps.canCapture - (attacker, defender) => boolean
- * @param {Function} deps.isMutualDestruction - (attacker, defender) => boolean
- * @param {Function} deps.pieceValue - (rank) => number (higher = more valuable)
- * @param {Function} deps.getValidCaptures - (board, x, y, team) => Array<{x,y}>
- * @param {Function} deps.getValidMoves - (board, x, y) => Array<{x,y}>
- * @returns {{type, from?, to?, x?, y?}|null}
+ * Pick the best capture among all legal captures (one-step lookahead).
+ * @param {Array} board
+ * @param {string} aiTeam
+ * @param {Object} deps - same shape as smartAiDecide deps
+ * @param {number} [size] - board size (default board.length)
+ * @returns {{type:'capture',from:{x,y},to:{x,y}}|null}
  */
-function smartAiDecide(state, aiTeam, deps) {
-  const board = state.board;
-  const { canCapture, isMutualDestruction, pieceValue, getValidCaptures, getValidMoves } = deps;
-
-  // Priority 1: capture (one-step lookahead for counter-attack risk)
+function chooseBestCapture(board, aiTeam, deps, size) {
+  const dims = _boardDims(board, deps.inBounds);
+  const N = size || dims.size;
+  const { canCapture, isMutualDestruction, pieceValue, getValidCaptures } = deps;
   const allCaptures = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
+  for (let y = 0; y < N; y++) {
+    for (let x = 0; x < N; x++) {
       const card = board[y][x];
       if (!card || !card.faceUp || card.team !== aiTeam) continue;
       const targets = getValidCaptures(board, x, y, aiTeam);
@@ -236,8 +247,8 @@ function smartAiDecide(state, aiTeam, deps) {
         const t = targets[k];
         const target = board[t.y][t.x];
         const mutual = isMutualDestruction(card, target);
-        const attVal = pieceValue(card.rank);
-        const defVal = pieceValue(target.rank);
+        const attVal = pieceValue(card, target, "attacker");
+        const defVal = pieceValue(target, card, "defender");
         let score;
         if (mutual) {
           // Mutual destruction: net = enemy loss - own loss
@@ -245,7 +256,14 @@ function smartAiDecide(state, aiTeam, deps) {
         } else {
           // Normal capture: simulate and check if attacker would be captured next turn
           const futureBoard = simulateCapture(board, { x, y }, t, false);
-          const exposed = isPositionUnderThreat(futureBoard, t.x, t.y, aiTeam, canCapture);
+          const exposed = isPositionUnderThreat(
+            futureBoard,
+            t.x,
+            t.y,
+            aiTeam,
+            canCapture,
+            deps.inBounds
+          );
           score = defVal - (exposed ? attVal : 0);
         }
         allCaptures.push({
@@ -259,131 +277,240 @@ function smartAiDecide(state, aiTeam, deps) {
       }
     }
   }
-  if (allCaptures.length > 0) {
-    allCaptures.sort((a, b) => {
-      // Primary: highest expected score
-      if (a.score !== b.score) return b.score - a.score;
-      // Tiebreakers preserve legacy behavior:
-      //  prefer non-mutual, lower defender rank (higher value),
-      //  higher attacker rank (preserve high-value attackers)
-      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
-      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
-      return b.attackerRank - a.attackerRank;
-    });
-    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
-  }
+  if (allCaptures.length === 0) return null;
+  allCaptures.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
+    if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
+    return b.attackerRank - a.attackerRank;
+  });
+  return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
+}
 
-  // Priority 2: flip (avoid flipping next to own face-up pieces)
+/**
+ * Pick the best face-down cell to flip. Penalises being adjacent to own
+ * high-value pieces (any flipped enemy could capture them next turn).
+ * @param {Array} board
+ * @param {string} aiTeam
+ * @param {Object} deps
+ * @param {number} [size]
+ * @returns {{type:'flip',x:number,y:number}|null}
+ */
+function chooseBestFlip(board, aiTeam, deps, size) {
+  const dims = _boardDims(board, deps.inBounds);
+  const N = size || dims.size;
+  const { pieceValue } = deps;
   const faceDownCells = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
+  for (let y = 0; y < N; y++) {
+    for (let x = 0; x < N; x++) {
       const card = board[y][x];
       if (card && !card.faceUp) faceDownCells.push({ x, y });
     }
   }
-  if (faceDownCells.length > 0) {
-    // Find own piece values at risk (most valuable own piece adjacent to flip)
-    const scored = faceDownCells.map((pos) => {
-      let maxAdjOwnVal = 0;
-      let adjEnemyCount = 0;
-      for (let i = 0; i < DIRECTIONS.length; i++) {
-        const nx = pos.x + DIRECTIONS[i].dx;
-        const ny = pos.y + DIRECTIONS[i].dy;
-        if (!inBounds(nx, ny)) continue;
-        const c = board[ny][nx];
-        if (!c || !c.faceUp) continue;
-        if (c.team === aiTeam) {
-          const v = pieceValue(c.rank);
-          if (v > maxAdjOwnVal) maxAdjOwnVal = v;
-        } else {
-          adjEnemyCount++;
-        }
-      }
-      // Penalty: risk of flipping enemy that captures adjacent own piece
-      // Bonus: adjacent enemies (newly flipped own piece could threaten them)
-      // Slight bias toward the centre for strategic flexibility
-      const distFromCenter = Math.abs(pos.x - 1.5) + Math.abs(pos.y - 1.5);
-      const score = adjEnemyCount * 0.5 - maxAdjOwnVal * 1.0 - distFromCenter * 0.1;
-      return { pos, score };
-    });
-    scored.sort((a, b) => b.score - a.score);
-    const topScore = scored[0].score;
-    const top = scored.filter((s) => s.score === topScore);
-    const pick = top[Math.floor(Math.random() * top.length)].pos;
-    return { type: "flip", x: pick.x, y: pick.y };
-  }
+  if (faceDownCells.length === 0) return null;
 
-  // Priority 3: move (escape threats, approach prey, avoid suicide)
+  const center = (N - 1) / 2;
+  const scored = faceDownCells.map((pos) => {
+    let maxAdjOwnVal = 0;
+    let adjEnemyCount = 0;
+    for (let i = 0; i < DIRECTIONS.length; i++) {
+      const nx = pos.x + DIRECTIONS[i].dx;
+      const ny = pos.y + DIRECTIONS[i].dy;
+      if (!dims.inBounds(nx, ny)) continue;
+      const c = board[ny][nx];
+      if (!c || !c.faceUp) continue;
+      if (c.team === aiTeam) {
+        const v = pieceValue(c, null, "self");
+        if (v > maxAdjOwnVal) maxAdjOwnVal = v;
+      } else {
+        adjEnemyCount++;
+      }
+    }
+    const distFromCenter = Math.abs(pos.x - center) + Math.abs(pos.y - center);
+    const score = adjEnemyCount * 0.5 - maxAdjOwnVal * 1.0 - distFromCenter * 0.1;
+    return { pos, score };
+  });
+  scored.sort((a, b) => b.score - a.score);
+  const topScore = scored[0].score;
+  const top = scored.filter((s) => s.score === topScore);
+  const pick = top[Math.floor(Math.random() * top.length)].pos;
+  return { type: "flip", x: pick.x, y: pick.y };
+}
+
+/**
+ * Pick the best move. Heuristics:
+ * - escape from threat: bonus
+ * - walk into a threatened cell: heavy penalty
+ * - bring our piece next to a capturable enemy: bonus
+ * - generic Manhattan reduction toward nearest enemy: tiny bias
+ * @param {Array} board
+ * @param {string} aiTeam
+ * @param {Object} deps
+ * @param {number} [size]
+ * @returns {{type:'move',from:{x,y},to:{x,y}}|null}
+ */
+function chooseBestMove(board, aiTeam, deps, size) {
+  const dims = _boardDims(board, deps.inBounds);
+  const N = size || dims.size;
+  const { canCapture, pieceValue, getValidMoves } = deps;
   const allMoves = [];
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
+  for (let y = 0; y < N; y++) {
+    for (let x = 0; x < N; x++) {
       const card = board[y][x];
       if (!card || !card.faceUp || card.team !== aiTeam) continue;
       const targets = getValidMoves(board, x, y);
       for (let k = 0; k < targets.length; k++) {
         const t = targets[k];
-        const cardVal = pieceValue(card.rank);
+        const cardVal = pieceValue(card, null, "self");
         let score = 0;
 
-        const currThreatened = isPositionUnderThreat(board, x, y, aiTeam, canCapture);
+        const currThreatened = isPositionUnderThreat(
+          board,
+          x,
+          y,
+          aiTeam,
+          canCapture,
+          deps.inBounds
+        );
         const futureBoard = simulateMove(board, { x, y }, t);
-        const futureThreatened = isPositionUnderThreat(futureBoard, t.x, t.y, aiTeam, canCapture);
+        const futureThreatened = isPositionUnderThreat(
+          futureBoard,
+          t.x,
+          t.y,
+          aiTeam,
+          canCapture,
+          deps.inBounds
+        );
 
         if (currThreatened && !futureThreatened) {
-          // Escaping danger
           score += cardVal;
         } else if (!currThreatened && futureThreatened) {
-          // Walking into danger (suicide) - heavy penalty
           score -= cardVal * 1.5;
         } else if (currThreatened && futureThreatened) {
-          // Still in danger
           score -= cardVal * 0.5;
         }
 
-        // Reward approaching a capturable enemy (sets up next-turn capture)
         let approachBonus = 0;
         for (let i = 0; i < DIRECTIONS.length; i++) {
           const nx = t.x + DIRECTIONS[i].dx;
           const ny = t.y + DIRECTIONS[i].dy;
-          if (!inBounds(nx, ny)) continue;
+          if (!dims.inBounds(nx, ny)) continue;
           const enemy = futureBoard[ny][nx];
           if (!enemy || !enemy.faceUp || enemy.team === aiTeam) continue;
           if (canCapture(card, enemy)) {
-            const ev = pieceValue(enemy.rank);
+            const ev = pieceValue(enemy, card, "defender");
             if (ev > approachBonus) approachBonus = ev;
           }
         }
         score += approachBonus * 0.5;
 
-        // Slight preference for advancing toward enemy face-up pieces
-        // (encourages activity rather than wandering aimlessly)
-        const enemyDistDelta = nearestEnemyDelta(board, x, y, t, aiTeam);
+        const enemyDistDelta = nearestEnemyDelta(board, x, y, t, aiTeam, N);
         score += enemyDistDelta * 0.05;
 
         allMoves.push({ from: { x, y }, to: t, score });
       }
     }
   }
-  if (allMoves.length > 0) {
-    allMoves.sort((a, b) => b.score - a.score);
-    const topScore = allMoves[0].score;
-    const top = allMoves.filter((m) => m.score === topScore);
-    const pick = top[Math.floor(Math.random() * top.length)];
-    return { type: "move", from: pick.from, to: pick.to };
-  }
+  if (allMoves.length === 0) return null;
+  allMoves.sort((a, b) => b.score - a.score);
+  const topScore = allMoves[0].score;
+  const top = allMoves.filter((m) => m.score === topScore);
+  const pick = top[Math.floor(Math.random() * top.length)];
+  return { type: "move", from: pick.from, to: pick.to };
+}
 
+/**
+ * Smart AI decision with one-step lookahead heuristics.
+ *
+ * Action priority (kept compatible with original greedy AI):
+ *   1. capture - choose the highest-scoring capture (counter-attack risk aware)
+ *   2. flip    - choose a face-down cell that is least risky to flip
+ *   3. move    - choose a move that escapes/avoids threats and approaches prey
+ *
+ * The pieceValue dependency is invoked as `pieceValue(card, otherCard?, role?)`.
+ * Plain rank-based games can ignore the extra arguments. Games where value
+ * depends on context (e.g. carrying a weapon) can use them.
+ *
+ * @param {Object} state - game state with board/currentTeam etc.
+ * @param {string} aiTeam - team controlled by AI
+ * @param {Object} deps - game-specific dependencies
+ * @param {Function} deps.canCapture - (attacker, defender) => boolean
+ * @param {Function} deps.isMutualDestruction - (attacker, defender) => boolean
+ * @param {Function} deps.pieceValue - (card, otherCard?, role?) => number
+ * @param {Function} deps.getValidCaptures - (board, x, y, team) => Array<{x,y}>
+ * @param {Function} deps.getValidMoves - (board, x, y) => Array<{x,y}>
+ * @param {Function} [deps.inBounds] - (x, y) => boolean (defaults to 4x4 / board size)
+ * @returns {{type, from?, to?, x?, y?}|null}
+ */
+/**
+ * Smart AI decision with one-step lookahead heuristics.
+ *
+ * Action priority (kept compatible with original greedy AI):
+ *   1. capture - choose the highest-scoring capture (counter-attack risk aware)
+ *   2. flip    - choose a face-down cell that is least risky to flip
+ *   3. move    - choose a move that escapes/avoids threats and approaches prey
+ *
+ * The pieceValue dependency is invoked as `pieceValue(card, otherCard?, role?)`.
+ * Plain rank-based games can ignore the extra arguments. Games where value
+ * depends on context (e.g. carrying a weapon) can use them.
+ *
+ * @param {Object} state - game state with board/currentTeam etc.
+ * @param {string} aiTeam - team controlled by AI
+ * @param {Object} deps - game-specific dependencies
+ * @param {Function} deps.canCapture - (attacker, defender) => boolean
+ * @param {Function} deps.isMutualDestruction - (attacker, defender) => boolean
+ * @param {Function} deps.pieceValue - (rank) or (card, other?, role?) => number
+ * @param {Function} deps.getValidCaptures - (board, x, y, team) => Array<{x,y}>
+ * @param {Function} deps.getValidMoves - (board, x, y) => Array<{x,y}>
+ * @param {Function} [deps.inBounds] - (x, y) => boolean (defaults to board size)
+ * @returns {{type, from?, to?, x?, y?}|null}
+ */
+function smartAiDecide(state, aiTeam, deps) {
+  // Wrap a legacy pieceValue(rank) signature so the new helpers can call
+  // pieceValue(card, otherCard?, role?) uniformly.
+  const wrappedDeps = Object.assign({}, deps, { pieceValue: wrapPieceValue(deps.pieceValue) });
+  const board = state.board;
+
+  const cap = chooseBestCapture(board, aiTeam, wrappedDeps);
+  if (cap) return cap;
+  const flip = chooseBestFlip(board, aiTeam, wrappedDeps);
+  if (flip) return flip;
+  const mv = chooseBestMove(board, aiTeam, wrappedDeps);
+  if (mv) return mv;
   return null;
+}
+
+/**
+ * Accept either a legacy `pieceValue(rank)` or a richer
+ * `pieceValue(card, otherCard?, role?)` and always return the latter shape
+ * for the helpers above.
+ */
+function wrapPieceValue(fn) {
+  if (typeof fn !== "function") {
+    return function () {
+      return 0;
+    };
+  }
+  return function (card, otherCard, role) {
+    if (!card) return 0;
+    // Legacy callers: receive only rank
+    if (fn.length <= 1) {
+      return fn(card.rank);
+    }
+    return fn(card, otherCard, role);
+  };
 }
 
 /**
  * Manhattan-distance reduction toward the nearest enemy face-up piece.
  * Positive = moving closer, negative = moving away, 0 = no enemy or unchanged.
  */
-function nearestEnemyDelta(board, fromX, fromY, to, ownTeam) {
+function nearestEnemyDelta(board, fromX, fromY, to, ownTeam, size) {
+  const N = size || board.length;
   let bestBefore = Infinity;
   let bestAfter = Infinity;
-  for (let y = 0; y < 4; y++) {
-    for (let x = 0; x < 4; x++) {
+  for (let y = 0; y < N; y++) {
+    for (let x = 0; x < N; x++) {
       const c = board[y][x];
       if (!c || !c.faceUp || c.team === ownTeam) continue;
       const dBefore = Math.abs(x - fromX) + Math.abs(y - fromY);
@@ -437,5 +564,9 @@ if (typeof module !== "undefined" && module.exports) {
     simulateMove: simulateMove,
     simulateCapture: simulateCapture,
     smartAiDecide: smartAiDecide,
+    chooseBestCapture: chooseBestCapture,
+    chooseBestFlip: chooseBestFlip,
+    chooseBestMove: chooseBestMove,
+    wrapPieceValue: wrapPieceValue,
   };
 }

--- a/apps/common/card-game-core.test.js
+++ b/apps/common/card-game-core.test.js
@@ -259,3 +259,181 @@ describe("createBaseState", () => {
     expect(state.gameOver).toBe(false);
   });
 });
+// ============================================================
+// AI helper utilities tests
+// ============================================================
+const {
+  isPositionUnderThreat,
+  simulateMove,
+  simulateCapture,
+  smartAiDecide,
+} = require("./card-game-core.js");
+
+// Standard 1-8 rank capture rule with reversal: rank 8 captures rank 1
+function rankCanCapture(att, def) {
+  if (att.team === def.team) return false;
+  if (att.rank === 8 && def.rank === 1) return true;
+  if (att.rank === 1 && def.rank === 8) return false;
+  return att.rank <= def.rank;
+}
+
+function isMutual(att, def) {
+  return att.rank === def.rank;
+}
+
+function pieceValueStd(rank) {
+  if (rank === 1) return 10;
+  if (rank === 8) return 5;
+  return 9 - rank;
+}
+
+function pieceCard(team, rank, faceUp) {
+  return { team: team, rank: rank, faceUp: faceUp !== false };
+}
+
+describe("isPositionUnderThreat", () => {
+  it("returns false when there are no enemies adjacent", () => {
+    var board = emptyBoard();
+    board[1][1] = pieceCard("red", 3, true);
+    expect(isPositionUnderThreat(board, 1, 1, "red", rankCanCapture)).toBe(false);
+  });
+  it("returns true when an adjacent enemy can capture", () => {
+    var board = emptyBoard();
+    board[1][1] = pieceCard("red", 3, true);
+    // Lion (rank 2) captures rank 3
+    board[1][2] = pieceCard("blue", 2, true);
+    expect(isPositionUnderThreat(board, 1, 1, "red", rankCanCapture)).toBe(true);
+  });
+  it("returns false when adjacent enemy is too weak", () => {
+    var board = emptyBoard();
+    board[1][1] = pieceCard("red", 1, true);
+    // Cat (rank 7) cannot capture elephant (rank 1)
+    board[1][2] = pieceCard("blue", 7, true);
+    expect(isPositionUnderThreat(board, 1, 1, "red", rankCanCapture)).toBe(false);
+  });
+  it("ignores face-down enemies", () => {
+    var board = emptyBoard();
+    board[1][1] = pieceCard("red", 3, true);
+    board[1][2] = pieceCard("blue", 1, false);
+    expect(isPositionUnderThreat(board, 1, 1, "red", rankCanCapture)).toBe(false);
+  });
+});
+
+describe("simulateMove", () => {
+  it("does not mutate original board", () => {
+    var board = emptyBoard();
+    board[0][0] = pieceCard("red", 1, true);
+    var newBoard = simulateMove(board, { x: 0, y: 0 }, { x: 1, y: 0 });
+    expect(board[0][0]).not.toBeNull();
+    expect(newBoard[0][0]).toBeNull();
+    expect(newBoard[0][1]).toBe(board[0][0]);
+  });
+});
+
+describe("simulateCapture", () => {
+  it("normal capture moves attacker into defender", () => {
+    var board = emptyBoard();
+    board[0][0] = pieceCard("red", 1, true);
+    board[0][1] = pieceCard("blue", 2, true);
+    var newBoard = simulateCapture(board, { x: 0, y: 0 }, { x: 1, y: 0 }, false);
+    expect(newBoard[0][0]).toBeNull();
+    expect(newBoard[0][1]).toBe(board[0][0]);
+  });
+  it("mutual destruction clears both squares", () => {
+    var board = emptyBoard();
+    board[0][0] = pieceCard("red", 1, true);
+    board[0][1] = pieceCard("blue", 1, true);
+    var newBoard = simulateCapture(board, { x: 0, y: 0 }, { x: 1, y: 0 }, true);
+    expect(newBoard[0][0]).toBeNull();
+    expect(newBoard[0][1]).toBeNull();
+  });
+});
+
+describe("smartAiDecide", () => {
+  function makeDeps() {
+    return {
+      canCapture: rankCanCapture,
+      isMutualDestruction: isMutual,
+      pieceValue: pieceValueStd,
+      getValidCaptures: function (board, x, y, team) {
+        return getValidCaptures(board, x, y, team, rankCanCapture);
+      },
+      getValidMoves: getValidMoves,
+    };
+  }
+
+  it("prefers a safe high-value capture", () => {
+    var board = emptyBoard();
+    // red elephant captures blue lion (rank 1 vs rank 2), no enemies adjacent after
+    board[1][1] = pieceCard("red", 1, true);
+    board[1][2] = pieceCard("blue", 2, true);
+    var state = { board: board, currentTeam: "red" };
+    var decision = smartAiDecide(state, "red", makeDeps());
+    expect(decision).not.toBeNull();
+    expect(decision.type).toBe("capture");
+    expect(decision.from).toEqual({ x: 1, y: 1 });
+    expect(decision.to).toEqual({ x: 2, y: 1 });
+  });
+
+  it("avoids a capture that exposes attacker to a stronger enemy", () => {
+    var board = emptyBoard();
+    // Red lion(2) can capture blue cat(7), but after move would be next to blue elephant(1) and get captured.
+    // Red also has a safer capture: red dog(6) captures blue cat... actually let's set:
+    // red lion at (1,1) can capture blue dog(6) at (1,2) -> after move at (1,2),
+    // adjacent to blue elephant(1) at (1,3) which captures lion(2). Score: 3 - 8 = -5.
+    // red wolf(5) at (3,3) can capture blue cat(7) at (3,2) -> after move at (3,2),
+    // no enemies adjacent. Score: 2.
+    // AI should prefer red wolf capture.
+    board[1][1] = pieceCard("red", 2, true); // lion
+    board[1][2] = pieceCard("blue", 6, true); // dog
+    board[1][3] = pieceCard("blue", 1, true); // elephant adjacent -> threatens after capture
+    board[3][3] = pieceCard("red", 5, true); // wolf
+    board[3][2] = pieceCard("blue", 7, true); // cat
+    var state = { board: board, currentTeam: "red" };
+    var decision = smartAiDecide(state, "red", makeDeps());
+    expect(decision.type).toBe("capture");
+    expect(decision.from).toEqual({ x: 3, y: 3 });
+    expect(decision.to).toEqual({ x: 2, y: 3 });
+  });
+
+  it("returns flip when no captures and face-down cards exist", () => {
+    var board = emptyBoard();
+    board[0][0] = pieceCard("red", 1, true);
+    board[3][3] = pieceCard("blue", 2, false);
+    var state = { board: board, currentTeam: "red" };
+    var decision = smartAiDecide(state, "red", makeDeps());
+    expect(decision).not.toBeNull();
+    expect(decision.type).toBe("flip");
+  });
+
+  it("escapes a threatened position via move", () => {
+    var board = emptyBoard();
+    // Red rank-3 at (1,1), threatened by blue rank-2 at (1,2). Empty cell at (0,1) and (1,0) etc.
+    board[1][1] = pieceCard("red", 3, true);
+    board[1][2] = pieceCard("blue", 2, true);
+    // After moving red to (1,0), no enemy adjacent -> safe.
+    var state = { board: board, currentTeam: "red" };
+    var decision = smartAiDecide(state, "red", makeDeps());
+    expect(decision).not.toBeNull();
+    expect(decision.type).toBe("move");
+    // Should not move into a threatened cell (e.g. (2,1) is empty too but not threatened either)
+    // Just verify it picked a safe cell
+    var futureBoard = simulateMove(board, decision.from, decision.to);
+    expect(isPositionUnderThreat(futureBoard, decision.to.x, decision.to.y, "red", rankCanCapture)).toBe(
+      false
+    );
+  });
+
+  it("returns null when there are no legal actions", () => {
+    var board = emptyBoard();
+    // Red rank-7 surrounded by stronger blue pieces; all adjacent are own-team unable to capture
+    board[1][1] = pieceCard("red", 7, true);
+    board[1][0] = pieceCard("blue", 2, true);
+    board[1][2] = pieceCard("blue", 3, true);
+    board[0][1] = pieceCard("blue", 4, true);
+    board[2][1] = pieceCard("blue", 5, true);
+    var state = { board: board, currentTeam: "red" };
+    var decision = smartAiDecide(state, "red", makeDeps());
+    expect(decision).toBeNull();
+  });
+});

--- a/apps/common/card-game-core.test.js
+++ b/apps/common/card-game-core.test.js
@@ -419,9 +419,9 @@ describe("smartAiDecide", () => {
     // Should not move into a threatened cell (e.g. (2,1) is empty too but not threatened either)
     // Just verify it picked a safe cell
     var futureBoard = simulateMove(board, decision.from, decision.to);
-    expect(isPositionUnderThreat(futureBoard, decision.to.x, decision.to.y, "red", rankCanCapture)).toBe(
-      false
-    );
+    expect(
+      isPositionUnderThreat(futureBoard, decision.to.x, decision.to.y, "red", rankCanCapture)
+    ).toBe(false);
   });
 
   it("returns null when there are no legal actions", () => {

--- a/scripts/ai-shootout.mjs
+++ b/scripts/ai-shootout.mjs
@@ -1,0 +1,162 @@
+// AI shootout: compare new (smart) AI vs simple greedy AI for the four games.
+// Runs N games where both sides use AI; new AI plays one team, legacy AI plays the other.
+// Tracks win rate. Designed as a quick sanity check; not a deterministic guarantee.
+
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+// Legacy AI implementation (greedy) - mirrors the original aiDecide.
+function legacyAiDecide(state, aiTeam, deps) {
+  const { canCapture, isMutualDestruction, getValidCaptures, getValidMoves } = deps;
+  const board = state.board;
+
+  const allCaptures = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getValidCaptures(board, x, y, aiTeam);
+      for (const t of targets) {
+        const target = board[t.y][t.x];
+        const mutual = isMutualDestruction(card, target);
+        allCaptures.push({
+          from: { x, y },
+          to: t,
+          defenderRank: target.rank,
+          attackerRank: card.rank,
+          mutual,
+        });
+      }
+    }
+  }
+  if (allCaptures.length > 0) {
+    allCaptures.sort((a, b) => {
+      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
+      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
+      return b.attackerRank - a.attackerRank;
+    });
+    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
+  }
+
+  const faceDownCells = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (card && !card.faceUp) faceDownCells.push({ x, y });
+    }
+  }
+  if (faceDownCells.length > 0) {
+    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
+    return { type: "flip", x: pick.x, y: pick.y };
+  }
+
+  const allMoves = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getValidMoves(board, x, y);
+      for (const t of targets) {
+        allMoves.push({ from: { x, y }, to: t });
+      }
+    }
+  }
+  if (allMoves.length > 0) {
+    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
+    return { type: "move", from: pick.from, to: pick.to };
+  }
+  return null;
+}
+
+function playGame(game, smartTeam, legacyTeam, makeDeps) {
+  const state = game.createGameState("pvp");
+  // Manually start
+  state.currentTeam = smartTeam;
+  state.firstPlayer = smartTeam;
+  let steps = 0;
+  while (!state.gameOver && steps < 500) {
+    steps++;
+    const team = state.currentTeam;
+    const deps = makeDeps();
+    const decision =
+      team === smartTeam ? game.aiDecide(state, team) : legacyAiDecide(state, team, deps);
+    if (!decision) break;
+    if (decision.type === "flip") {
+      game.flipCard(state, decision.x, decision.y);
+    } else if (decision.type === "move") {
+      game.moveCard(state, decision.from, decision.to);
+    } else if (decision.type === "capture") {
+      game.captureCard(state, decision.from, decision.to);
+    }
+    const result = game.checkGameOver(state.board, state.currentTeam);
+    if (result.ended) {
+      state.gameOver = true;
+      state.winner = result.winner;
+      break;
+    }
+  }
+  return state.winner;
+}
+
+function runShootout(name, game, teamA, teamB, makeDeps, games = 200) {
+  let smartWins = 0;
+  let legacyWins = 0;
+  let draws = 0;
+  for (let i = 0; i < games; i++) {
+    // Alternate which side starts to avoid first-move bias
+    const smart = i % 2 === 0 ? teamA : teamB;
+    const legacy = smart === teamA ? teamB : teamA;
+    const winner = playGame(game, smart, legacy, makeDeps);
+    if (winner === smart) smartWins++;
+    else if (winner === legacy) legacyWins++;
+    else draws++;
+  }
+  console.log(
+    `${name}: smart ${smartWins} - legacy ${legacyWins} (draws ${draws}) over ${games} games`
+  );
+}
+
+// Animal Chess
+{
+  const game = require("../apps/card-game/animal-chess/game.js");
+  const makeDeps = () => ({
+    canCapture: game.canCapture,
+    isMutualDestruction: game.isMutualDestruction,
+    getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
+    getValidMoves: game.getValidMoves,
+  });
+  runShootout("animal-chess", game, "red", "blue", makeDeps);
+}
+// Cat and Mouse
+{
+  const game = require("../apps/card-game/cat-and-mouse/game.js");
+  const makeDeps = () => ({
+    canCapture: game.canCapture,
+    isMutualDestruction: game.isMutualDestruction,
+    getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
+    getValidMoves: game.getValidMoves,
+  });
+  runShootout("cat-and-mouse", game, "red", "blue", makeDeps);
+}
+// Little Emperor
+{
+  const game = require("../apps/card-game/little-emperor/game.js");
+  const makeDeps = () => ({
+    canCapture: game.canCapture,
+    isMutualDestruction: game.isMutualDestruction,
+    getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
+    getValidMoves: game.getValidMoves,
+  });
+  runShootout("little-emperor", game, "red", "blue", makeDeps);
+}
+// Dragon Tiger Fight
+{
+  const game = require("../apps/card-game/dragon-tiger-fight/game.js");
+  const makeDeps = () => ({
+    canCapture: game.canCapture,
+    isMutualDestruction: game.isMutualDestruction,
+    getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
+    getValidMoves: game.getValidMoves,
+  });
+  runShootout("dragon-tiger-fight", game, "dragon", "tiger", makeDeps);
+}

--- a/scripts/ai-shootout.mjs
+++ b/scripts/ai-shootout.mjs
@@ -1,12 +1,17 @@
-// AI shootout: compare new (smart) AI vs simple greedy AI for the four games.
-// Runs N games where both sides use AI; new AI plays one team, legacy AI plays the other.
-// Tracks win rate. Designed as a quick sanity check; not a deterministic guarantee.
+// AI shootout: compare new (smart) AI vs simple legacy AI for the card games.
+// Each game runs N matches. New AI plays one side, legacy AI the other; sides
+// alternate to remove first-move bias. Reports win counts.
+//
+// Designed as a quick sanity check; not a deterministic guarantee.
 
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 
-// Legacy AI implementation (greedy) - mirrors the original aiDecide.
-function legacyAiDecide(state, aiTeam, deps) {
+// ============================================================
+// Generic legacy AI for 4x4 capture/flip/move games (no carry, no flag)
+// Mirrors the original aiDecide of animal-chess / cat-and-mouse / little-emperor / dragon-tiger-fight.
+// ============================================================
+function legacyAiDecide4x4(state, aiTeam, deps) {
   const { isMutualDestruction, getValidCaptures, getValidMoves } = deps;
   const board = state.board;
 
@@ -18,7 +23,7 @@ function legacyAiDecide(state, aiTeam, deps) {
       const targets = getValidCaptures(board, x, y, aiTeam);
       for (const t of targets) {
         const target = board[t.y][t.x];
-        const mutual = isMutualDestruction(card, target);
+        const mutual = isMutualDestruction ? isMutualDestruction(card, target) : false;
         allCaptures.push({
           from: { x, y },
           to: t,
@@ -38,15 +43,15 @@ function legacyAiDecide(state, aiTeam, deps) {
     return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
   }
 
-  const faceDownCells = [];
+  const faceDown = [];
   for (let y = 0; y < 4; y++) {
     for (let x = 0; x < 4; x++) {
       const card = board[y][x];
-      if (card && !card.faceUp) faceDownCells.push({ x, y });
+      if (card && !card.faceUp) faceDown.push({ x, y });
     }
   }
-  if (faceDownCells.length > 0) {
-    const pick = faceDownCells[Math.floor(Math.random() * faceDownCells.length)];
+  if (faceDown.length > 0) {
+    const pick = faceDown[Math.floor(Math.random() * faceDown.length)];
     return { type: "flip", x: pick.x, y: pick.y };
   }
 
@@ -56,9 +61,7 @@ function legacyAiDecide(state, aiTeam, deps) {
       const card = board[y][x];
       if (!card || !card.faceUp || card.team !== aiTeam) continue;
       const targets = getValidMoves(board, x, y);
-      for (const t of targets) {
-        allMoves.push({ from: { x, y }, to: t });
-      }
+      for (const t of targets) allMoves.push({ from: { x, y }, to: t });
     }
   }
   if (allMoves.length > 0) {
@@ -68,45 +71,200 @@ function legacyAiDecide(state, aiTeam, deps) {
   return null;
 }
 
-function playGame(game, smartTeam, legacyTeam, makeDeps) {
+// ============================================================
+// Legacy AI for chinese-army-chess (5x5, with flag-capture priority)
+// ============================================================
+function legacyAiDecideArmyChess(state, aiTeam, deps) {
+  const { canCaptureFlag, getValidCaptures, getValidMoves, resolveCombat } = deps;
+  const board = state.board;
+
+  // Priority 1: capture flag
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 5; x++) {
+      const piece = board[y][x];
+      if (!piece || !piece.faceUp || piece.team !== aiTeam) continue;
+      const flagResult = canCaptureFlag(board, x, y, aiTeam);
+      if (flagResult) {
+        return { type: "move", from: { x, y }, to: { x: flagResult.flagX, y: flagResult.flagY } };
+      }
+    }
+  }
+
+  // Priority 2: capture
+  const allCaptures = [];
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 5; x++) {
+      const piece = board[y][x];
+      if (!piece || !piece.faceUp || piece.team !== aiTeam) continue;
+      const targets = getValidCaptures(board, x, y, aiTeam);
+      for (const t of targets) {
+        const target = board[t.y][t.x];
+        const combatResult = resolveCombat(piece, target);
+        const mutual = combatResult === "mutual_destruction";
+        allCaptures.push({
+          from: { x, y },
+          to: t,
+          defenderRank: target.rank !== null ? target.rank : 999,
+          attackerRank: piece.rank !== null ? piece.rank : 999,
+          mutual,
+        });
+      }
+    }
+  }
+  if (allCaptures.length > 0) {
+    allCaptures.sort((a, b) => {
+      if (a.mutual !== b.mutual) return a.mutual ? 1 : -1;
+      if (a.defenderRank !== b.defenderRank) return a.defenderRank - b.defenderRank;
+      return b.attackerRank - a.attackerRank;
+    });
+    return { type: "capture", from: allCaptures[0].from, to: allCaptures[0].to };
+  }
+
+  // Priority 3: flip
+  const faceDown = [];
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 5; x++) {
+      const piece = board[y][x];
+      if (piece && !piece.faceUp) faceDown.push({ x, y });
+    }
+  }
+  if (faceDown.length > 0) {
+    const pick = faceDown[Math.floor(Math.random() * faceDown.length)];
+    return { type: "flip", x: pick.x, y: pick.y };
+  }
+
+  // Priority 4: move
+  const allMoves = [];
+  for (let y = 0; y < 5; y++) {
+    for (let x = 0; x < 5; x++) {
+      const piece = board[y][x];
+      if (!piece || !piece.faceUp || piece.team !== aiTeam) continue;
+      const targets = getValidMoves(board, x, y, aiTeam);
+      for (const t of targets) allMoves.push({ from: { x, y }, to: t });
+    }
+  }
+  if (allMoves.length > 0) {
+    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
+    return { type: "move", from: pick.from, to: pick.to };
+  }
+  return null;
+}
+
+// ============================================================
+// Legacy AI for knife-kills-chicken (4x4 with carry weapon)
+// ============================================================
+function legacyAiDecideKnife(state, aiTeam, deps) {
+  const { getValidCaptures, getValidMoves, getCarryTargets } = deps;
+  const board = state.board;
+
+  const allCaptures = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getValidCaptures(board, x, y, aiTeam);
+      for (const t of targets) allCaptures.push({ from: { x, y }, to: t });
+    }
+  }
+  if (allCaptures.length > 0) {
+    const pick = allCaptures[Math.floor(Math.random() * allCaptures.length)];
+    return { type: "capture", from: pick.from, to: pick.to };
+  }
+
+  const allCarries = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getCarryTargets(board, x, y, aiTeam);
+      for (const t of targets) allCarries.push({ from: { x, y }, to: t });
+    }
+  }
+  if (allCarries.length > 0) {
+    const pick = allCarries[Math.floor(Math.random() * allCarries.length)];
+    return { type: "carry", from: pick.from, to: pick.to };
+  }
+
+  const faceDown = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (card && !card.faceUp) faceDown.push({ x, y });
+    }
+  }
+  if (faceDown.length > 0) {
+    const pick = faceDown[Math.floor(Math.random() * faceDown.length)];
+    return { type: "flip", x: pick.x, y: pick.y };
+  }
+
+  const allMoves = [];
+  for (let y = 0; y < 4; y++) {
+    for (let x = 0; x < 4; x++) {
+      const card = board[y][x];
+      if (!card || !card.faceUp || card.team !== aiTeam) continue;
+      const targets = getValidMoves(board, x, y);
+      for (const t of targets) allMoves.push({ from: { x, y }, to: t });
+    }
+  }
+  if (allMoves.length > 0) {
+    const pick = allMoves[Math.floor(Math.random() * allMoves.length)];
+    return { type: "move", from: pick.from, to: pick.to };
+  }
+  return null;
+}
+
+// ============================================================
+// Generic match runner. Strategies are 4-arg: (game, state, aiTeam, deps).
+// `stepGame` applies a decision to the state and returns updated state.
+// `checkOver` reports whether the game finished after the step.
+// ============================================================
+function playGame({ game, smartTeam, legacyTeam, deps, smartFn, legacyFn, stepGame, checkOver }) {
   const state = game.createGameState("pvp");
-  // Manually start
   state.currentTeam = smartTeam;
   state.firstPlayer = smartTeam;
+  state.teamAssigned = true;
+  state.aiFirst = false;
   let steps = 0;
   while (!state.gameOver && steps < 500) {
     steps++;
     const team = state.currentTeam;
-    const deps = makeDeps();
-    const decision =
-      team === smartTeam ? game.aiDecide(state, team) : legacyAiDecide(state, team, deps);
-    if (!decision) break;
-    if (decision.type === "flip") {
-      game.flipCard(state, decision.x, decision.y);
-    } else if (decision.type === "move") {
-      game.moveCard(state, decision.from, decision.to);
-    } else if (decision.type === "capture") {
-      game.captureCard(state, decision.from, decision.to);
-    }
-    const result = game.checkGameOver(state.board, state.currentTeam);
-    if (result.ended) {
+    const decision = team === smartTeam ? smartFn(state, team) : legacyFn(state, team, deps);
+    if (!decision) {
+      // No legal action -> the side without options loses.
       state.gameOver = true;
-      state.winner = result.winner;
+      state.winner = team === smartTeam ? legacyTeam : smartTeam;
+      break;
+    }
+    stepGame(state, decision);
+    const over = checkOver(state);
+    if (over.ended) {
+      state.gameOver = true;
+      state.winner = over.winner;
       break;
     }
   }
   return state.winner;
 }
 
-function runShootout(name, game, teamA, teamB, makeDeps, games = 200) {
+function runShootout(name, gameFactory, games = 200) {
   let smartWins = 0;
   let legacyWins = 0;
   let draws = 0;
   for (let i = 0; i < games; i++) {
-    // Alternate which side starts to avoid first-move bias
-    const smart = i % 2 === 0 ? teamA : teamB;
-    const legacy = smart === teamA ? teamB : teamA;
-    const winner = playGame(game, smart, legacy, makeDeps);
+    const cfg = gameFactory();
+    const flip = i % 2 === 0;
+    const smart = flip ? cfg.teamA : cfg.teamB;
+    const legacy = smart === cfg.teamA ? cfg.teamB : cfg.teamA;
+    const winner = playGame({
+      game: cfg.game,
+      smartTeam: smart,
+      legacyTeam: legacy,
+      deps: cfg.deps,
+      smartFn: cfg.smartFn,
+      legacyFn: cfg.legacyFn,
+      stepGame: cfg.stepGame,
+      checkOver: cfg.checkOver,
+    });
     if (winner === smart) smartWins++;
     else if (winner === legacy) legacyWins++;
     else draws++;
@@ -116,47 +274,107 @@ function runShootout(name, game, teamA, teamB, makeDeps, games = 200) {
   );
 }
 
-// Animal Chess
-{
-  const game = require("../apps/card-game/animal-chess/game.js");
-  const makeDeps = () => ({
+// ============================================================
+// Game configurations
+// ============================================================
+
+// Generic 4x4 capture/flip/move game (animal-chess / cat-and-mouse / little-emperor)
+function configSimple4x4(game, teamA, teamB) {
+  const deps = {
     canCapture: game.canCapture,
     isMutualDestruction: game.isMutualDestruction,
     getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
     getValidMoves: game.getValidMoves,
-  });
-  runShootout("animal-chess", game, "red", "blue", makeDeps);
+  };
+  return {
+    game,
+    teamA,
+    teamB,
+    deps,
+    smartFn: (state, team) => game.aiDecide(state, team),
+    legacyFn: legacyAiDecide4x4,
+    stepGame: (state, decision) => {
+      if (decision.type === "flip") game.flipCard(state, decision.x, decision.y);
+      else if (decision.type === "move") game.moveCard(state, decision.from, decision.to);
+      else if (decision.type === "capture") game.captureCard(state, decision.from, decision.to);
+    },
+    checkOver: (state) => game.checkGameOver(state.board, state.currentTeam),
+  };
 }
-// Cat and Mouse
-{
-  const game = require("../apps/card-game/cat-and-mouse/game.js");
-  const makeDeps = () => ({
-    canCapture: game.canCapture,
-    isMutualDestruction: game.isMutualDestruction,
+
+// dragon-tiger-fight uses dragon/tiger team names
+function configDragonTiger(game) {
+  return configSimple4x4(game, "dragon", "tiger");
+}
+
+// chinese-army-chess (5x5 + flag)
+function configArmyChess(game) {
+  const deps = {
+    canCaptureFlag: game.canCaptureFlag,
     getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
     getValidMoves: game.getValidMoves,
-  });
-  runShootout("cat-and-mouse", game, "red", "blue", makeDeps);
+    resolveCombat: game.resolveCombat,
+  };
+  return {
+    game,
+    teamA: "red",
+    teamB: "blue",
+    deps,
+    smartFn: (state, team) => game.aiDecide(state, team),
+    legacyFn: legacyAiDecideArmyChess,
+    stepGame: (state, decision) => {
+      if (decision.type === "flip") game.flipCard(state, decision.x, decision.y);
+      else if (decision.type === "move") game.moveCard(state, decision.from, decision.to);
+      else if (decision.type === "capture") game.captureCard(state, decision.from, decision.to);
+    },
+    // checkGameOver(state) returns {ended, winner}; this game's signature
+    // takes state, not (board, team).
+    checkOver: (state) => game.checkGameOver(state),
+  };
 }
-// Little Emperor
-{
-  const game = require("../apps/card-game/little-emperor/game.js");
-  const makeDeps = () => ({
-    canCapture: game.canCapture,
-    isMutualDestruction: game.isMutualDestruction,
+
+// knife-kills-chicken (4x4 + carry)
+function configKnife(game) {
+  const deps = {
     getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
     getValidMoves: game.getValidMoves,
-  });
-  runShootout("little-emperor", game, "red", "blue", makeDeps);
+    getCarryTargets: (b, x, y, t) => game.getCarryTargets(b, x, y, t),
+  };
+  return {
+    game,
+    teamA: "red",
+    teamB: "blue",
+    deps,
+    smartFn: (state, team) => game.aiDecide(state, team),
+    legacyFn: legacyAiDecideKnife,
+    stepGame: (state, decision) => {
+      if (decision.type === "flip") game.flipCard(state, decision.x, decision.y);
+      else if (decision.type === "move") game.moveCard(state, decision.from, decision.to);
+      else if (decision.type === "capture") game.captureCard(state, decision.from, decision.to);
+      else if (decision.type === "carry") game.carryWeapon(state, decision.from, decision.to);
+    },
+    checkOver: (state) => game.checkGameOver(state.board, state.currentTeam),
+  };
 }
-// Dragon Tiger Fight
-{
-  const game = require("../apps/card-game/dragon-tiger-fight/game.js");
-  const makeDeps = () => ({
-    canCapture: game.canCapture,
-    isMutualDestruction: game.isMutualDestruction,
-    getValidCaptures: (b, x, y, t) => game.getValidCaptures(b, x, y, t),
-    getValidMoves: game.getValidMoves,
-  });
-  runShootout("dragon-tiger-fight", game, "dragon", "tiger", makeDeps);
-}
+
+// ============================================================
+// Run
+// ============================================================
+runShootout("animal-chess", () =>
+  configSimple4x4(require("../apps/card-game/animal-chess/game.js"), "red", "blue")
+);
+runShootout("cat-and-mouse", () =>
+  configSimple4x4(require("../apps/card-game/cat-and-mouse/game.js"), "red", "blue")
+);
+runShootout("little-emperor", () =>
+  configSimple4x4(require("../apps/card-game/little-emperor/game.js"), "red", "blue")
+);
+runShootout("dragon-tiger-fight", () =>
+  configDragonTiger(require("../apps/card-game/dragon-tiger-fight/game.js"))
+);
+runShootout("chinese-army-chess", () =>
+  configArmyChess(require("../apps/card-game/chinese-army-chess/game.js"))
+);
+runShootout("knife-kills-chicken", () =>
+  configKnife(require("../apps/card-game/knife-kills-chicken/game.js"))
+);

--- a/scripts/ai-shootout.mjs
+++ b/scripts/ai-shootout.mjs
@@ -7,7 +7,7 @@ const require = createRequire(import.meta.url);
 
 // Legacy AI implementation (greedy) - mirrors the original aiDecide.
 function legacyAiDecide(state, aiTeam, deps) {
-  const { canCapture, isMutualDestruction, getValidCaptures, getValidMoves } = deps;
+  const { isMutualDestruction, getValidCaptures, getValidMoves } = deps;
   const board = state.board;
 
   const allCaptures = [];


### PR DESCRIPTION
## 关联 Issue
Closes #19

## 概述
为 `apps/card-game/` 下全部 **6 款** 人机卡牌游戏替换原本的纯贪心 AI，改为带一步前瞻（lookahead）的启发式决策：

- 兽棋（animal-chess）
- 猫捉老鼠（cat-and-mouse）
- 小皇帝（little-emperor）
- 龙虎斗（dragon-tiger-fight）
- **陆战棋（chinese-army-chess）** ← 新增
- **杀鸡用牛刀（knife-kills-chicken）** ← 新增

## 主要改动

### `apps/common/card-game-core.js`
共享 AI 工具：
- `isPositionUnderThreat(board, x, y, ownTeam, canCaptureFn, inBoundsFn?)`：判断某格是否会被相邻敌人吃掉
- `simulateMove` / `simulateCapture`：克隆棋盘后执行操作，用于一步前瞻
- `smartAiDecide(state, aiTeam, deps)`：通用智能决策入口
- **新增** `chooseBestCapture` / `chooseBestFlip` / `chooseBestMove`：拆出来的子步骤，便于自带额外阶段（扛刀/抱军旗）的游戏组合调用
- **新增** `wrapPieceValue`：兼容 legacy `pieceValue(rank)` 与新版 `pieceValue(card, other?, role?)` 两种签名
- AI helpers 现在支持任意尺寸 board（不再硬编码 4×4），新增可选 `inBounds` 依赖供 5×5 棋盘使用

决策优先级保持与原版兼容（吃 > 翻 > 走），但每个阶段都加入了前瞻和评分：

| 阶段 | 旧策略 | 新策略 |
|---|---|---|
| 吃子 | 选 `defenderRank` 最低、避免同归于尽 | 评 `score = 收益 - 反吃风险`，避免送子 |
| 翻牌 | 完全随机 | 避开己方高价值棋子相邻；偏好棋盘中心 |
| 走子 | 完全随机 | 逃离威胁加分、走入威胁重罚、靠近猎物加分 |

### 4×4 通用游戏 (`animal-chess` / `cat-and-mouse` / `little-emperor` / `dragon-tiger-fight`)
- 各自的 `aiDecide` 简化为对 `smartAiDecide` 的调用
- 各自实现 `pieceValue(rank)` 评估函数（含逆袭奖励：rank 8 由于能吃 rank 1，价值高于普通弱子）

### 陆战棋 (`chinese-army-chess`)
5×5 棋盘 + 抱军旗胜利条件，规则更复杂（炸弹/地雷/军旗）。
- 决策优先级：抱军旗 → 智能吃子 → **追赶军旗（新增）** → 智能翻牌 → 智能走子
- 关键洞察：陆战棋约 96% 胜局来自抱军旗，AI 必须**主动**用最小普通棋子靠近军旗，而非被动避免威胁
- 新增 `approachFlagMove`：当军旗已翻开，让最小普通棋子按曼哈顿距离严格接近，并避免落入威胁格
- `pieceValue` 考虑特殊棋子：司令=12, 工兵=6（排雷逆袭）, 炸弹=7, 地雷=4, 军旗=100, 其余按军衔递减

### 杀鸡用牛刀 (`knife-kills-chicken`)
4×4 棋盘 + 独特的扛刀/扛枪机制 + 循环克制关系。
- 决策优先级：智能吃子 → **智能扛刀/扛枪（新增）** → 智能翻牌 → 智能走子
- `pieceValue` 考虑扛刀/扛枪升级：人扛刀 5→8、癞痢扛枪 4→8、火箭=12
- 新增 `pickBestCarry`：根据棋盘上敌方鸡/老虎数量动态计算"扛刀解锁吃鸡"/"扛枪解锁吃虎"的协同价值

### `apps/common/card-game-core.test.js`
新增 12 个单元测试覆盖：
- `isPositionUnderThreat` / `simulateMove` / `simulateCapture`
- `smartAiDecide` 的吃子风险规避、翻牌、逃跑、null 兜底

### `apps/card-game/chinese-army-chess/game.test.js` / `apps/card-game/knife-kills-chicken/game.test.js`
各新增 4 个智能 AI 行为测试（避免送子、追赶军旗 / 优先扛刀解锁、被威胁时逃离、null 兜底）。

### `scripts/ai-shootout.mjs`
AI 对战评估脚本：现在支持全部 6 款游戏（含 5×5 棋盘和 carry action）。

## 验证

### 测试
全量测试通过：**1561 / 1561**（旧 1541 + 共享 core 12 + 陆战棋 4 + 杀鸡用牛刀 4）

```
npx vitest run
Test Files  25 passed (25)
     Tests  1561 passed (1561)
```

### Lint
`npx eslint` 无新增 error / warning。

### AI 对战实测（每款 200 局，新 AI vs 旧贪心 AI，先后手交替）
| 游戏 | 新 AI 胜 | 旧 AI 胜 | 平局 |
|---|---|---|---|
| 兽棋 | **121** | 63 | 16 |
| 猫捉老鼠 | **123** | 60 | 17 |
| 小皇帝 | **140** | 47 | 13 |
| 龙虎斗 | **121** | 60 | 19 |
| 陆战棋 | **114** | 86 | 0 |
| 杀鸡用牛刀 | **130** | 31 | 39 |

新 AI 在所有 6 款游戏上对旧贪心 AI 均有显著胜率优势。

## 兼容性
- 所有原有的 `aiDecide` 行为契约（返回结构 `{type, from?, to?, x?, y?}`、优先级 capture > flip > move 等）保持不变
- 现有 100+ 条针对 `aiDecide` 的测试用例全部通过，未做任何调整
