### PR TITLE
fix(card-game): treat mutual-destruction wipeout as draw (#22)

### DIFF
--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -233,6 +233,8 @@ function checkGameOver(board, currentTeam) {
       }
     }
   }
+  // Both sides have no pieces (mutual destruction wiped out remaining pieces) -> draw
+  if (redCount === 0 && blueCount === 0) return { ended: true, winner: "draw" };
   if (redCount === 0) return { ended: true, winner: "blue" };
   if (blueCount === 0) return { ended: true, winner: "red" };
   if (!hasAnyLegalAction(board, currentTeam)) {
@@ -527,6 +529,11 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
+    if (winner === "draw") {
+      $winnerText.textContent = "平局！";
+      $gameOver.style.display = "flex";
+      return;
+    }
     // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
     const label = getCurrentPlayerLabel({
       mode: gameState.mode,

--- a/apps/card-game/animal-chess/game.test.js
+++ b/apps/card-game/animal-chess/game.test.js
@@ -792,6 +792,13 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(false);
     expect(result.winner).toBeNull();
   });
+
+  it("双方棋子都被同归于尽吃光时为平局", () => {
+    const board = emptyBoard();
+    const result = checkGameOver(board, "red");
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -221,6 +221,8 @@ function checkGameOver(board, currentTeam) {
       }
     }
   }
+  // Both sides have no pieces (mutual destruction wiped out remaining pieces) -> draw
+  if (redCount === 0 && blueCount === 0) return { ended: true, winner: "draw" };
   if (redCount === 0) return { ended: true, winner: "blue" };
   if (blueCount === 0) return { ended: true, winner: "red" };
   if (!hasAnyLegalAction(board, currentTeam)) {
@@ -348,6 +350,11 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
+    if (winner === "draw") {
+      $winnerText.textContent = "平局！";
+      $gameOver.style.display = "flex";
+      return;
+    }
     // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
     const label = getCurrentPlayerLabel({
       mode: gameState.mode,

--- a/apps/card-game/cat-and-mouse/game.test.js
+++ b/apps/card-game/cat-and-mouse/game.test.js
@@ -795,6 +795,13 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(false);
     expect(result.winner).toBeNull();
   });
+
+  it("双方棋子都被同归于尽吃光时为平局", () => {
+    const board = emptyBoard();
+    const result = checkGameOver(board, "red");
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -353,6 +353,8 @@ function checkGameOver(board, currentTeam) {
       }
     }
   }
+  // Both sides have no pieces (mutual destruction wiped out remaining pieces) -> draw
+  if (dragonCount === 0 && tigerCount === 0) return { ended: true, winner: "draw" };
   if (dragonCount === 0) return { ended: true, winner: "tiger" };
   if (tigerCount === 0) return { ended: true, winner: "dragon" };
   if (!hasAnyLegalAction(board, currentTeam)) {
@@ -637,6 +639,11 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
+    if (winner === "draw") {
+      $winnerText.textContent = "平局！";
+      $gameOver.style.display = "flex";
+      return;
+    }
     // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of dragon/tiger
     const label = getCurrentPlayerLabel({
       mode: gameState.mode,

--- a/apps/card-game/dragon-tiger-fight/game.test.js
+++ b/apps/card-game/dragon-tiger-fight/game.test.js
@@ -986,6 +986,13 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(false);
     expect(result.winner).toBeNull();
   });
+
+  it("双方棋子都被同归于尽吃光时为平局", () => {
+    const board = emptyBoard();
+    const result = checkGameOver(board, "dragon");
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -357,6 +357,8 @@ function checkGameOver(board, currentTeam) {
     }
   }
 
+  // Both sides have no cards (mutual destruction wiped out remaining pieces) -> draw
+  if (redCount === 0 && blueCount === 0) return { ended: true, winner: "draw" };
   // One side has no cards -> that side loses
   if (redCount === 0) return { ended: true, winner: "blue" };
   if (blueCount === 0) return { ended: true, winner: "red" };
@@ -802,6 +804,11 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
+    if (winner === "draw") {
+      $winnerText.textContent = "平局！";
+      $gameOver.style.display = "flex";
+      return;
+    }
     // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
     const label = getCurrentPlayerLabel({
       mode: gameState.mode,

--- a/apps/card-game/knife-kills-chicken/game.test.js
+++ b/apps/card-game/knife-kills-chicken/game.test.js
@@ -1166,12 +1166,12 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.winner).toBeNull();
   });
 
-  it("空board时双方都无牌，红方先判定为0 → 蓝方获胜", () => {
+  it("空board时双方都无牌为平局", () => {
     const board = emptyBoard();
     const result = checkGameOver(board, "red");
-    // Red 0 cards, blue also 0, but red detected 0 first -> blue wins
+    // Both sides have no cards (mutual destruction wiped out everything) -> draw
     expect(result.ended).toBe(true);
-    expect(result.winner).toBe("blue");
+    expect(result.winner).toBe("draw");
   });
 });
 

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -227,6 +227,8 @@ function checkGameOver(board, currentTeam) {
       }
     }
   }
+  // Both sides have no pieces (mutual destruction wiped out remaining pieces) -> draw
+  if (redCount === 0 && blueCount === 0) return { ended: true, winner: "draw" };
   if (redCount === 0) return { ended: true, winner: "blue" };
   if (blueCount === 0) return { ended: true, winner: "red" };
   if (!hasAnyLegalAction(board, currentTeam)) {
@@ -356,6 +358,11 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
+    if (winner === "draw") {
+      $winnerText.textContent = "平局！";
+      $gameOver.style.display = "flex";
+      return;
+    }
     // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
     const label = getCurrentPlayerLabel({
       mode: gameState.mode,

--- a/apps/card-game/little-emperor/game.test.js
+++ b/apps/card-game/little-emperor/game.test.js
@@ -864,11 +864,11 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.winner).toBeNull();
   });
 
-  it("空board时双方都无牌，红方先判定为0 → 蓝方获胜", () => {
+  it("空board时双方都无牌为平局", () => {
     const board = emptyBoard();
     const result = checkGameOver(board, "red");
     expect(result.ended).toBe(true);
-    expect(result.winner).toBe("blue");
+    expect(result.winner).toBe("draw");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #22.

When the final move is a mutual-destruction capture that empties both sides of the board, the original `checkGameOver` logic would award victory to the second-checked side (e.g. tiger) instead of declaring a draw, because the `dragonCount === 0` branch matched first.

## Root cause

```js
if (dragonCount === 0) return { ended: true, winner: "tiger" };
if (tigerCount === 0) return { ended: true, winner: "dragon" };
```

When both counts are 0, the first check short-circuits and the game ends with a wrong winner.

## Affected games

All card games with mutual-destruction (兑子) mechanics had the same bug:

- `dragon-tiger-fight` — same-rank mutual destruction
- `animal-chess` — same-rank mutual destruction
- `cat-and-mouse` — same-rank mutual destruction
- `little-emperor` — same-rank mutual destruction
- `knife-kills-chicken` — rocket triggers mutual destruction

`chinese-army-chess` is not affected (the flag piece cannot move or be destroyed in capture, so both sides cannot be wiped out simultaneously).

## Changes

1. `checkGameOver`: detect `bothCount === 0` first and return `{ ended: true, winner: "draw" }`.
2. `showGameOverScreen`: render `平局！` when `winner === "draw"`.
3. Updated/added unit tests for the empty-board draw scenario.

## Verification

- `npm test`: 1564 / 1564 passed
- `npm run lint`: 0 errors