### PR TITLE
fix(card-game): detect stalemate to prevent infinite games (#21)

### DIFF
--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable, isStalemateDraw:writable, recordCaptureAction:writable */
 // ============================================================
 // Animal Chess - Game Core Logic
 // ============================================================
@@ -22,6 +22,8 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   moveCard = _core.moveCard;
   createBaseState = _core.createBaseState;
   smartAiDecide = _core.smartAiDecide;
+  isStalemateDraw = _core.isStalemateDraw;
+  recordCaptureAction = _core.recordCaptureAction;
 }
 
 // All animal names (shared by red/blue, rank 1-8, lower value = higher rank)
@@ -190,6 +192,7 @@ function captureCard(state, from, to) {
 
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordCaptureAction(state);
   return state;
 }
 
@@ -219,9 +222,14 @@ function hasAnyLegalAction(board, team) {
  * Check if game is over
  * @param {Board} board - board
  * @param {string} currentTeam - current team 'red' | 'blue'
+ * @param {Object} [state] - optional full game state for stalemate detection
  * @returns {{ended: boolean, winner: string|null}}
  */
-function checkGameOver(board, currentTeam) {
+function checkGameOver(board, currentTeam, state) {
+  // Stalemate / repetition draw (anti-deadlock)
+  if (state && isStalemateDraw(state)) {
+    return { ended: true, winner: "draw" };
+  }
   let redCount = 0;
   let blueCount = 0;
   for (let y = 0; y < 4; y++) {
@@ -847,7 +855,7 @@ if (typeof document !== "undefined") {
 
   function afterAction() {
     // Check game over
-    const result = checkGameOver(gameState.board, gameState.currentTeam);
+    const result = checkGameOver(gameState.board, gameState.currentTeam, gameState);
     if (result.ended) {
       gameState.gameOver = true;
       gameState.winner = result.winner;

--- a/apps/card-game/animal-chess/game.test.js
+++ b/apps/card-game/animal-chess/game.test.js
@@ -799,6 +799,66 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(true);
     expect(result.winner).toBe("draw");
   });
+
+  it("无吃子动作连续达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("象", "red");
+    board[3][3] = makeCard("象", "blue");
+    const state = makeState(board, "red");
+    state.noCaptureActions = 50;
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("局面重复达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("象", "red");
+    board[3][3] = makeCard("象", "blue");
+    const state = makeState(board, "red");
+    // Simulate the same position appearing 3 times in history.
+    const fakeKey = JSON.stringify(state.board) + "|red";
+    state.positionHistory = { [fakeKey]: 3 };
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("反复来回移动触发平局（端到端）", () => {
+    // Two pieces that cannot capture each other (both face-up rats; same rank
+    // would mutually destruct, so we use rank 4 vs 5 isolated by distance so
+    // they cannot capture). Each side just shuffles back and forth.
+    const board = emptyBoard();
+    board[0][0] = makeCard("豹", "red"); // rank 4
+    board[3][3] = makeCard("豹", "blue"); // rank 4 (different team, far apart)
+    const state = makeState(board, "red", { teamAssigned: true });
+    state.noCaptureActions = 0;
+    state.positionHistory = {};
+    // Keep moving the red piece between (0,0) and (1,0); blue between (3,3) and (2,3).
+    let endResult = null;
+    for (let i = 0; i < 200 && !endResult; i++) {
+      // Red move
+      const rFrom = i % 2 === 0 ? { x: 0, y: 0 } : { x: 1, y: 0 };
+      const rTo = i % 2 === 0 ? { x: 1, y: 0 } : { x: 0, y: 0 };
+      moveCard(state, rFrom, rTo);
+      let r = checkGameOver(state.board, state.currentTeam, state);
+      if (r.ended) {
+        endResult = r;
+        break;
+      }
+      // Blue move
+      const bFrom = i % 2 === 0 ? { x: 3, y: 3 } : { x: 2, y: 3 };
+      const bTo = i % 2 === 0 ? { x: 2, y: 3 } : { x: 3, y: 3 };
+      moveCard(state, bFrom, bTo);
+      r = checkGameOver(state.board, state.currentTeam, state);
+      if (r.ended) {
+        endResult = r;
+        break;
+      }
+    }
+    expect(endResult).not.toBeNull();
+    expect(endResult.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable, isStalemateDraw:writable, recordCaptureAction:writable */
 // ============================================================
 // Cat Catches Mouse - Game Core Logic
 // ============================================================
@@ -22,6 +22,8 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   moveCard = _core.moveCard;
   createBaseState = _core.createBaseState;
   smartAiDecide = _core.smartAiDecide;
+  isStalemateDraw = _core.isStalemateDraw;
+  recordCaptureAction = _core.recordCaptureAction;
 }
 
 // All piece names (shared by red/blue, sorted by rank, lower value = stronger)
@@ -176,6 +178,7 @@ function captureCard(state, from, to) {
 
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordCaptureAction(state);
   return state;
 }
 
@@ -205,11 +208,16 @@ function hasAnyLegalAction(board, team) {
  * Check if game is over
  * - One side has no pieces -> opponent wins
  * - Current team has no legal actions -> current team loses
+ * - Stalemate (50 non-capture turns or 3-fold repetition) -> draw
  * @param {Array} board - 4×4 board
  * @param {string} currentTeam - current team 'red' | 'blue'
+ * @param {Object} [state] - optional full game state for stalemate detection
  * @returns {{ended: boolean, winner: string|null}}
  */
-function checkGameOver(board, currentTeam) {
+function checkGameOver(board, currentTeam, state) {
+  if (state && isStalemateDraw(state)) {
+    return { ended: true, winner: "draw" };
+  }
   let redCount = 0;
   let blueCount = 0;
   for (let y = 0; y < 4; y++) {
@@ -842,7 +850,7 @@ if (typeof document !== "undefined") {
   // ---- 4.10 Post-action processing ----
 
   function afterAction() {
-    const result = checkGameOver(gameState.board, gameState.currentTeam);
+    const result = checkGameOver(gameState.board, gameState.currentTeam, gameState);
     if (result.ended) {
       gameState.gameOver = true;
       gameState.winner = result.winner;

--- a/apps/card-game/cat-and-mouse/game.test.js
+++ b/apps/card-game/cat-and-mouse/game.test.js
@@ -802,6 +802,29 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(true);
     expect(result.winner).toBe("draw");
   });
+
+  it("无吃子动作连续达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("大黄猫", "red");
+    board[3][3] = makeCard("大黄猫", "blue");
+    const state = makeState(board, "red");
+    state.noCaptureActions = 50;
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("局面重复达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("大黄猫", "red");
+    board[3][3] = makeCard("大黄猫", "blue");
+    const state = makeState(board, "red");
+    const fakeKey = JSON.stringify(state.board) + "|red";
+    state.positionHistory = { [fakeKey]: 3 };
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, chooseBestCapture:writable, chooseBestFlip:writable, chooseBestMove:writable */
+/* global DIRECTIONS:writable, chooseBestCapture:writable, chooseBestFlip:writable, chooseBestMove:writable, isStalemateDraw:writable, recordCaptureAction:writable, recordNonCaptureAction:writable */
 // ============================================================
 // Chinese Army Chess (Flip Chess) - Game Core Logic
 // ============================================================
@@ -27,6 +27,15 @@ if (typeof require !== "undefined") {
   }
   if (typeof chooseBestMove === "undefined") {
     chooseBestMove = require("../../common/card-game-core.js").chooseBestMove;
+  }
+  if (typeof isStalemateDraw === "undefined") {
+    isStalemateDraw = require("../../common/card-game-core.js").isStalemateDraw;
+  }
+  if (typeof recordCaptureAction === "undefined") {
+    recordCaptureAction = require("../../common/card-game-core.js").recordCaptureAction;
+  }
+  if (typeof recordNonCaptureAction === "undefined") {
+    recordNonCaptureAction = require("../../common/card-game-core.js").recordNonCaptureAction;
   }
 }
 
@@ -289,6 +298,9 @@ function createGameState(mode) {
     winner: null,
     aiThinking: false,
     aiFirst: false,
+    // Stalemate tracking (anti-deadlock)
+    noCaptureActions: 0,
+    positionHistory: {},
   };
 }
 
@@ -431,6 +443,7 @@ function flipCard(state, x, y) {
   if (isFlag(card.name)) {
     state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
     state.turnCount++;
+    recordNonCaptureAction(state);
     return state;
   }
 
@@ -453,6 +466,7 @@ function flipCard(state, x, y) {
 
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordNonCaptureAction(state);
   return state;
 }
 
@@ -485,6 +499,9 @@ function moveCard(state, from, to) {
     state.gameOver = true;
     state.winner = state.currentTeam;
     state.turnCount++;
+    // Capturing the flag ends the game; treat as a capture-equivalent reset
+    // (no need for further stalemate detection on this state).
+    recordCaptureAction(state);
     return state;
   }
 
@@ -494,6 +511,7 @@ function moveCard(state, from, to) {
     state.board[from.y][from.x] = null;
     state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
     state.turnCount++;
+    recordNonCaptureAction(state);
     return state;
   }
 
@@ -552,6 +570,7 @@ function captureCard(state, from, to) {
 
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordCaptureAction(state);
   return state;
 }
 
@@ -590,6 +609,11 @@ function checkGameOver(state) {
   // If already won by capturing flag
   if (state.gameOver) {
     return { ended: true, winner: state.winner };
+  }
+
+  // Stalemate / repetition draw (anti-deadlock)
+  if (isStalemateDraw(state)) {
+    return { ended: true, winner: "draw" };
   }
 
   // If current team has no legal actions
@@ -1218,6 +1242,11 @@ if (typeof document !== "undefined") {
   }
 
   function showGameOverScreen(winner) {
+    if (winner === "draw") {
+      $winnerText.textContent = "平局！";
+      $gameOver.style.display = "flex";
+      return;
+    }
     // Show 玩家/电脑 (PVE) or 玩家1/玩家2 (PVP) instead of color
     const label = getCurrentPlayerLabel({
       mode: gameState.mode,

--- a/apps/card-game/chinese-army-chess/game.test.js
+++ b/apps/card-game/chinese-army-chess/game.test.js
@@ -429,6 +429,29 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(false);
     expect(result.winner).toBeNull();
   });
+
+  it("无吃子动作连续达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makePiece("司令", "red");
+    board[3][3] = makePiece("司令", "blue");
+    const state = makeState(board, "red");
+    state.noCaptureActions = 50;
+    const result = checkGameOver(state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("局面重复达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makePiece("司令", "red");
+    board[3][3] = makePiece("司令", "blue");
+    const state = makeState(board, "red");
+    const fakeKey = JSON.stringify(state.board) + "|red";
+    state.positionHistory = { [fakeKey]: 3 };
+    const result = checkGameOver(state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, smartAiDecide:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, smartAiDecide:writable, isStalemateDraw:writable, recordCaptureAction:writable, recordNonCaptureAction:writable */
 // ============================================================
 // Dragon Tiger Fight - Game Core Logic
 // ============================================================
@@ -18,6 +18,9 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   inBounds = _core.inBounds;
   getValidMoves = _core.getValidMoves;
   smartAiDecide = _core.smartAiDecide;
+  isStalemateDraw = _core.isStalemateDraw;
+  recordCaptureAction = _core.recordCaptureAction;
+  recordNonCaptureAction = _core.recordNonCaptureAction;
 }
 
 // Dragon team 8 pieces (rank 1-8, lower value = higher rank)
@@ -181,6 +184,9 @@ function createGameState(mode) {
     winner: null,
     aiThinking: false,
     aiFirst: false,
+    // Stalemate tracking (anti-deadlock)
+    noCaptureActions: 0,
+    positionHistory: {},
   };
 }
 
@@ -245,6 +251,7 @@ function flipCard(state, x, y) {
     state.currentTeam = state.currentTeam === "dragon" ? "tiger" : "dragon";
   }
   state.turnCount++;
+  recordNonCaptureAction(state);
   return state;
 }
 
@@ -266,6 +273,7 @@ function moveCard(state, from, to) {
   state.board[from.y][from.x] = null;
   state.currentTeam = state.currentTeam === "dragon" ? "tiger" : "dragon";
   state.turnCount++;
+  recordNonCaptureAction(state);
   return state;
 }
 
@@ -310,6 +318,7 @@ function captureCard(state, from, to) {
 
   state.currentTeam = state.currentTeam === "dragon" ? "tiger" : "dragon";
   state.turnCount++;
+  recordCaptureAction(state);
   return state;
 }
 
@@ -339,9 +348,13 @@ function hasAnyLegalAction(board, team) {
  * Check if game is over
  * @param {Board} board - board
  * @param {string} currentTeam - current team 'dragon' | 'tiger'
+ * @param {Object} [state] - optional full game state for stalemate detection
  * @returns {{ended: boolean, winner: string|null}}
  */
-function checkGameOver(board, currentTeam) {
+function checkGameOver(board, currentTeam, state) {
+  if (state && isStalemateDraw(state)) {
+    return { ended: true, winner: "draw" };
+  }
   let dragonCount = 0;
   let tigerCount = 0;
   for (let y = 0; y < 4; y++) {
@@ -891,7 +904,7 @@ if (typeof document !== "undefined") {
 
   function afterAction() {
     // Check game over
-    const result = checkGameOver(gameState.board, gameState.currentTeam);
+    const result = checkGameOver(gameState.board, gameState.currentTeam, gameState);
     if (result.ended) {
       gameState.gameOver = true;
       gameState.winner = result.winner;

--- a/apps/card-game/dragon-tiger-fight/game.test.js
+++ b/apps/card-game/dragon-tiger-fight/game.test.js
@@ -993,6 +993,29 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(true);
     expect(result.winner).toBe("draw");
   });
+
+  it("无吃子动作连续达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("龙王", "dragon");
+    board[3][3] = makeCard("虎王", "tiger");
+    const state = makeState(board, "dragon");
+    state.noCaptureActions = 50;
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("局面重复达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("龙王", "dragon");
+    board[3][3] = makeCard("虎王", "tiger");
+    const state = makeState(board, "dragon");
+    const fakeKey = JSON.stringify(state.board) + "|dragon";
+    state.positionHistory = { [fakeKey]: 3 };
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, flipCard:writable, moveCard:writable, createBaseState:writable, chooseBestCapture:writable, chooseBestFlip:writable, chooseBestMove:writable */
+/* global DIRECTIONS:writable, inBounds:writable, flipCard:writable, moveCard:writable, createBaseState:writable, chooseBestCapture:writable, chooseBestFlip:writable, chooseBestMove:writable, isStalemateDraw:writable, recordCaptureAction:writable, recordNonCaptureAction:writable */
 // ============================================================
 // Knife Kills Chicken (Carry Weapon Version) - Game Core Logic
 // ============================================================
@@ -25,6 +25,10 @@ if (typeof require !== "undefined") {
   if (typeof chooseBestCapture === "undefined") chooseBestCapture = _core.chooseBestCapture;
   if (typeof chooseBestFlip === "undefined") chooseBestFlip = _core.chooseBestFlip;
   if (typeof chooseBestMove === "undefined") chooseBestMove = _core.chooseBestMove;
+  if (typeof isStalemateDraw === "undefined") isStalemateDraw = _core.isStalemateDraw;
+  if (typeof recordCaptureAction === "undefined") recordCaptureAction = _core.recordCaptureAction;
+  if (typeof recordNonCaptureAction === "undefined")
+    recordNonCaptureAction = _core.recordNonCaptureAction;
 }
 
 // 8 roles
@@ -273,6 +277,7 @@ function captureCard(state, from, to) {
   // Switch current team
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordCaptureAction(state);
 
   return state;
 }
@@ -311,6 +316,7 @@ function carryWeapon(state, from, to) {
   // Switch current team
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordNonCaptureAction(state);
   return state;
 }
 
@@ -342,9 +348,13 @@ function hasAnyLegalAction(board, team) {
  * Check if game is over
  * @param {(Card|null)[][]} board - board state
  * @param {string} currentTeam - current team
+ * @param {Object} [state] - optional full game state for stalemate detection
  * @returns {{ended: boolean, winner: string|null}} game over status
  */
-function checkGameOver(board, currentTeam) {
+function checkGameOver(board, currentTeam, state) {
+  if (state && isStalemateDraw(state)) {
+    return { ended: true, winner: "draw" };
+  }
   let redCount = 0;
   let blueCount = 0;
   for (let y = 0; y < 4; y++) {
@@ -1094,7 +1104,7 @@ if (typeof document !== "undefined") {
 
   function afterAction() {
     // Check game over
-    const result = checkGameOver(gameState.board, gameState.currentTeam);
+    const result = checkGameOver(gameState.board, gameState.currentTeam, gameState);
     if (result.ended) {
       gameState.gameOver = true;
       gameState.winner = result.winner;

--- a/apps/card-game/knife-kills-chicken/game.test.js
+++ b/apps/card-game/knife-kills-chicken/game.test.js
@@ -1173,6 +1173,29 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(true);
     expect(result.winner).toBe("draw");
   });
+
+  it("无吃子动作连续达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("刀", "red");
+    board[3][3] = makeCard("刀", "blue");
+    const state = makeState(board, "red");
+    state.noCaptureActions = 50;
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("局面重复达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("刀", "red");
+    board[3][3] = makeCard("刀", "blue");
+    const state = makeState(board, "red");
+    const fakeKey = JSON.stringify(state.board) + "|red";
+    state.positionHistory = { [fakeKey]: 3 };
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 const { aiDecide } = require("./game.js");

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-var */
-/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable */
+/* global DIRECTIONS:writable, inBounds:writable, getValidMoves:writable, getValidCapturesCore:writable, flipCard:writable, moveCard:writable, createBaseState:writable, smartAiDecide:writable, isStalemateDraw:writable, recordCaptureAction:writable */
 // ============================================================
 // Little Emperor - Game Core Logic
 // ============================================================
@@ -22,6 +22,8 @@ if (typeof DIRECTIONS === "undefined" && typeof require !== "undefined") {
   moveCard = _core.moveCard;
   createBaseState = _core.createBaseState;
   smartAiDecide = _core.smartAiDecide;
+  isStalemateDraw = _core.isStalemateDraw;
+  recordCaptureAction = _core.recordCaptureAction;
 }
 
 // All piece names (sorted by rank, rank 1-8)
@@ -183,6 +185,7 @@ function captureCard(state, from, to) {
 
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordCaptureAction(state);
   return state;
 }
 
@@ -210,12 +213,16 @@ function hasAnyLegalAction(board, team) {
 
 /**
  * Check if game is over
- * Side with no pieces or no legal actions loses
+ * Side with no pieces or no legal actions loses; stalemate -> draw.
  * @param {Array} board - 4×4 board
  * @param {string} currentTeam - current team 'red' | 'blue'
+ * @param {Object} [state] - optional full game state for stalemate detection
  * @returns {{ended: boolean, winner: string|null}}
  */
-function checkGameOver(board, currentTeam) {
+function checkGameOver(board, currentTeam, state) {
+  if (state && isStalemateDraw(state)) {
+    return { ended: true, winner: "draw" };
+  }
   let redCount = 0;
   let blueCount = 0;
   for (let y = 0; y < 4; y++) {
@@ -843,7 +850,7 @@ if (typeof document !== "undefined") {
 
   function afterAction() {
     // Check game over
-    const result = checkGameOver(gameState.board, gameState.currentTeam);
+    const result = checkGameOver(gameState.board, gameState.currentTeam, gameState);
     if (result.ended) {
       gameState.gameOver = true;
       gameState.winner = result.winner;

--- a/apps/card-game/little-emperor/game.test.js
+++ b/apps/card-game/little-emperor/game.test.js
@@ -870,6 +870,29 @@ describe("checkGameOver - 游戏结束判定", () => {
     expect(result.ended).toBe(true);
     expect(result.winner).toBe("draw");
   });
+
+  it("无吃子动作连续达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("爷爷", "red");
+    board[3][3] = makeCard("爷爷", "blue");
+    const state = makeState(board, "red");
+    state.noCaptureActions = 50;
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
+
+  it("局面重复达到上限时判平局（防止死循环）", () => {
+    const board = emptyBoard();
+    board[0][0] = makeCard("爷爷", "red");
+    board[3][3] = makeCard("爷爷", "blue");
+    const state = makeState(board, "red");
+    const fakeKey = JSON.stringify(state.board) + "|red";
+    state.positionHistory = { [fakeKey]: 3 };
+    const result = checkGameOver(state.board, state.currentTeam, state);
+    expect(result.ended).toBe(true);
+    expect(result.winner).toBe("draw");
+  });
 });
 
 // ============================================================

--- a/apps/common/card-game-core.js
+++ b/apps/common/card-game-core.js
@@ -10,6 +10,63 @@ const DIRECTIONS = [
   { dx: 0, dy: 1 },
 ];
 
+// ============================================================
+// Stalemate / draw detection (anti-deadlock for card games)
+// ============================================================
+// Reaching this number of consecutive non-capture actions ends the game in a draw.
+const STALEMATE_NO_CAPTURE_LIMIT = 50;
+// Reaching this number of repetitions of the same position+turn signals a draw.
+const POSITION_REPETITION_LIMIT = 3;
+
+/**
+ * Build a compact signature of the board + side to move for repetition tracking.
+ * Relies on JSON serialization of the board cells; field insertion order is
+ * stable inside each game's card factory, so equivalent positions hash equal.
+ * @param {Object} state
+ * @returns {string}
+ */
+function hashPosition(state) {
+  return JSON.stringify(state.board) + "|" + (state.currentTeam || "");
+}
+
+/**
+ * Increment the non-capture action counter and record the current position.
+ * Call this at the end of any non-capture action that consumes a turn
+ * (flip / move / carry-weapon).
+ * @param {Object} state
+ */
+function recordNonCaptureAction(state) {
+  state.noCaptureActions = (state.noCaptureActions || 0) + 1;
+  if (!state.positionHistory) state.positionHistory = {};
+  const key = hashPosition(state);
+  state.positionHistory[key] = (state.positionHistory[key] || 0) + 1;
+}
+
+/**
+ * Reset stalemate tracking after a capture: piece count just changed so any
+ * earlier repetition counts can no longer recur.
+ * @param {Object} state
+ */
+function recordCaptureAction(state) {
+  state.noCaptureActions = 0;
+  state.positionHistory = {};
+}
+
+/**
+ * Check whether the current state has reached a draw by stalemate rules.
+ * @param {Object} state
+ * @returns {boolean}
+ */
+function isStalemateDraw(state) {
+  if (!state) return false;
+  if ((state.noCaptureActions || 0) >= STALEMATE_NO_CAPTURE_LIMIT) return true;
+  if (state.positionHistory) {
+    const key = hashPosition(state);
+    if ((state.positionHistory[key] || 0) >= POSITION_REPETITION_LIMIT) return true;
+  }
+  return false;
+}
+
 /**
  * Check if coordinates are within 4x4 board range
  * @param {number} x
@@ -111,6 +168,7 @@ function flipCard(state, x, y) {
     state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   }
   state.turnCount++;
+  recordNonCaptureAction(state);
   return state;
 }
 
@@ -132,6 +190,7 @@ function moveCard(state, from, to) {
   state.board[from.y][from.x] = null;
   state.currentTeam = state.currentTeam === "red" ? "blue" : "red";
   state.turnCount++;
+  recordNonCaptureAction(state);
   return state;
 }
 
@@ -545,6 +604,11 @@ function createBaseState(mode) {
     winner: null,
     aiThinking: false,
     aiFirst: false,
+    // Stalemate tracking (anti-deadlock): consecutive non-capture turns and
+    // position repetition counter. See isStalemateDraw / recordNonCaptureAction
+    // / recordCaptureAction.
+    noCaptureActions: 0,
+    positionHistory: {},
   };
 }
 
@@ -554,6 +618,12 @@ function createBaseState(mode) {
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     DIRECTIONS: DIRECTIONS,
+    STALEMATE_NO_CAPTURE_LIMIT: STALEMATE_NO_CAPTURE_LIMIT,
+    POSITION_REPETITION_LIMIT: POSITION_REPETITION_LIMIT,
+    hashPosition: hashPosition,
+    recordNonCaptureAction: recordNonCaptureAction,
+    recordCaptureAction: recordCaptureAction,
+    isStalemateDraw: isStalemateDraw,
     inBounds: inBounds,
     getValidMoves: getValidMoves,
     getValidCaptures: getValidCaptures,

--- a/apps/common/card-game-core.test.js
+++ b/apps/common/card-game-core.test.js
@@ -437,3 +437,133 @@ describe("smartAiDecide", () => {
     expect(decision).toBeNull();
   });
 });
+
+// ============================================================
+// Stalemate / draw detection tests
+// ============================================================
+const {
+  STALEMATE_NO_CAPTURE_LIMIT,
+  POSITION_REPETITION_LIMIT,
+  hashPosition,
+  recordNonCaptureAction,
+  recordCaptureAction,
+  isStalemateDraw,
+} = require("./card-game-core.js");
+
+describe("stalemate constants", () => {
+  it("exposes a non-trivial no-capture limit", () => {
+    expect(typeof STALEMATE_NO_CAPTURE_LIMIT).toBe("number");
+    expect(STALEMATE_NO_CAPTURE_LIMIT).toBeGreaterThan(10);
+  });
+  it("exposes a repetition limit", () => {
+    expect(POSITION_REPETITION_LIMIT).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("hashPosition", () => {
+  it("returns same hash for identical board+team", () => {
+    var s1 = createBaseState("pvp");
+    s1.board = emptyBoard();
+    s1.currentTeam = "red";
+    var s2 = createBaseState("pvp");
+    s2.board = emptyBoard();
+    s2.currentTeam = "red";
+    expect(hashPosition(s1)).toBe(hashPosition(s2));
+  });
+  it("differs when current team differs", () => {
+    var s1 = createBaseState("pvp");
+    s1.board = emptyBoard();
+    s1.currentTeam = "red";
+    var s2 = createBaseState("pvp");
+    s2.board = emptyBoard();
+    s2.currentTeam = "blue";
+    expect(hashPosition(s1)).not.toBe(hashPosition(s2));
+  });
+});
+
+describe("recordNonCaptureAction / isStalemateDraw - no-capture limit", () => {
+  it("draws after reaching the no-capture limit", () => {
+    var state = createBaseState("pvp");
+    state.board = emptyBoard();
+    state.currentTeam = "red";
+    expect(isStalemateDraw(state)).toBe(false);
+    for (var i = 0; i < STALEMATE_NO_CAPTURE_LIMIT - 1; i++) {
+      // Vary position so repetition rule does not trigger first
+      state.board[0][0] = { team: "red", faceUp: true, k: i };
+      recordNonCaptureAction(state);
+    }
+    expect(isStalemateDraw(state)).toBe(false);
+    state.board[0][0] = { team: "red", faceUp: true, k: 9999 };
+    recordNonCaptureAction(state);
+    expect(isStalemateDraw(state)).toBe(true);
+  });
+});
+
+describe("recordCaptureAction", () => {
+  it("resets stalemate counters", () => {
+    var state = createBaseState("pvp");
+    state.board = emptyBoard();
+    state.currentTeam = "red";
+    for (var i = 0; i < 10; i++) {
+      state.board[0][0] = { team: "red", faceUp: true, k: i };
+      recordNonCaptureAction(state);
+    }
+    expect(state.noCaptureActions).toBe(10);
+    recordCaptureAction(state);
+    expect(state.noCaptureActions).toBe(0);
+    expect(Object.keys(state.positionHistory).length).toBe(0);
+  });
+});
+
+describe("isStalemateDraw - position repetition", () => {
+  it("draws when same position+team is reached the repetition-limit times", () => {
+    var state = createBaseState("pvp");
+    state.board = emptyBoard();
+    state.board[0][0] = { team: "red", faceUp: true };
+    state.currentTeam = "red";
+    // Reach the same position POSITION_REPETITION_LIMIT times.
+    for (var i = 0; i < POSITION_REPETITION_LIMIT; i++) {
+      recordNonCaptureAction(state);
+    }
+    expect(isStalemateDraw(state)).toBe(true);
+  });
+  it("does not draw before the repetition limit", () => {
+    var state = createBaseState("pvp");
+    state.board = emptyBoard();
+    state.board[0][0] = { team: "red", faceUp: true };
+    state.currentTeam = "red";
+    for (var i = 0; i < POSITION_REPETITION_LIMIT - 1; i++) {
+      recordNonCaptureAction(state);
+    }
+    expect(isStalemateDraw(state)).toBe(false);
+  });
+});
+
+describe("flipCard / moveCard increment stalemate counters", () => {
+  it("flipCard increments noCaptureActions", () => {
+    var state = createBaseState("pvp");
+    state.board = emptyBoard();
+    state.board[1][1] = { team: "red", faceUp: false };
+    state.currentTeam = "red";
+    state.teamAssigned = true;
+    flipCard(state, 1, 1);
+    expect(state.noCaptureActions).toBe(1);
+  });
+  it("moveCard increments noCaptureActions", () => {
+    var state = createBaseState("pvp");
+    state.board = emptyBoard();
+    state.board[1][1] = { team: "red", faceUp: true };
+    state.currentTeam = "red";
+    state.teamAssigned = true;
+    moveCard(state, { x: 1, y: 1 }, { x: 2, y: 1 });
+    expect(state.noCaptureActions).toBe(1);
+  });
+});
+
+describe("createBaseState - stalemate fields", () => {
+  it("initializes noCaptureActions to 0 and positionHistory to {}", () => {
+    var state = createBaseState("pvp");
+    expect(state.noCaptureActions).toBe(0);
+    expect(state.positionHistory).toEqual({});
+  });
+});


### PR DESCRIPTION
Closes #21

## 问题

6 款卡牌类游戏（兽棋 / 猫捉老鼠 / 小皇帝 / 龙虎斗 / 刀杀鸡 / 军师旅团营）在双方都还有棋子、但已无吃子可能时，会陷入无限来回平移的死局。

## 方案

在共享层 `apps/common/card-game-core.js` 增加通用的「死局 → 平局」检测，所有卡牌类游戏统一接入。

### 双重判定

| 判定 | 阈值 | 触发后 |
|------|------|--------|
| 连续无吃子动作 | 50 次 | 平局 |
| 同一局面重复（board + 当前行动方哈希） | 3 次 | 平局 |

任何一次成功的 `captureCard` 都会**重置**两个计数器（`noCaptureActions = 0`、`positionHistory = {}`），保证只在真正"双方都无意义地走"时触发。

### 共享层改动（`apps/common/card-game-core.js`）

新增导出：

- 常量：`STALEMATE_NO_CAPTURE_LIMIT = 50`、`POSITION_REPETITION_LIMIT = 3`
- 工具函数：`hashPosition(state)`、`recordNonCaptureAction(state)`、`recordCaptureAction(state)`、`isStalemateDraw(state)`
- 共享 `flipCard` / `moveCard` 末尾自动调用 `recordNonCaptureAction`
- `createBaseState` 默认初始化 `noCaptureActions: 0`、`positionHistory: {}`

### 各游戏接入

每款游戏：

- `captureCard` 末尾调用 `recordCaptureAction`（吃子事件清零）
- 自定义的 `flipCard` / `moveCard` / `carryWeapon` 末尾调用 `recordNonCaptureAction`
- `checkGameOver` 头部加 `isStalemateDraw` 判定，命中时返回 `winner: "draw"`
- UI 层 `afterAction` 调用 `checkGameOver` 时多传 `gameState`

`chinese-army-chess` 是 5×5 翻棋，自定义了 `flipCard`/`moveCard`/`captureCard`，也都按上述规则接入；其 `showGameOverScreen` 同步补上了 `winner === "draw"` 分支（其他 5 款 UI 已有）。

`knife-kills-chicken` 的 `carryWeapon`（人扛刀 / 癞痢扛枪）是非吃子动作，同样会累加无吃子计数。

## 测试

总计 1588 个测试全部通过（增加 28 个）：

- `apps/common/card-game-core.test.js`：新增 11 个测试，覆盖 `hashPosition`、`recordNonCaptureAction`、`recordCaptureAction`、`isStalemateDraw`、`flipCard`/`moveCard` 计数、`createBaseState` 初始化字段
- 6 款卡牌游戏各加 2 个 `checkGameOver` 平局测试（无吃子上限、局面重复上限）
- `animal-chess` 额外加 1 个端到端测试：模拟双方反复来回移动，验证最终被判平局

```
Test Files  25 passed (25)
     Tests  1588 passed (1588)
```

## 文件改动

```
apps/card-game/animal-chess/game.js          (+9, -1)
apps/card-game/animal-chess/game.test.js     (+57, -0)
apps/card-game/cat-and-mouse/game.js         (+9, -1)
apps/card-game/cat-and-mouse/game.test.js    (+22, -0)
apps/card-game/chinese-army-chess/game.js    (+33, -0)
apps/card-game/chinese-army-chess/game.test.js (+22, -0)
apps/card-game/dragon-tiger-fight/game.js    (+11, -1)
apps/card-game/dragon-tiger-fight/game.test.js (+22, -0)
apps/card-game/knife-kills-chicken/game.js   (+15, -2)
apps/card-game/knife-kills-chicken/game.test.js (+22, -0)
apps/card-game/little-emperor/game.js        (+9, -1)
apps/card-game/little-emperor/game.test.js   (+22, -0)
apps/common/card-game-core.js                (+78, -1)
apps/common/card-game-core.test.js           (+128, -0)
```