### PR TITLE
chore: SonarQube issue cleanup

### DIFF
--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -280,9 +280,10 @@ function evaluateBoard(board, aiPlayer) {
         if (isAI) {
           if (aiPlayer === RED) score += sign * r * WEIGHT_ADVANCE;
           else score += sign * (BOARD_SIZE - 1 - r) * WEIGHT_ADVANCE;
+        } else if (opponent === RED) {
+          score += sign * r * WEIGHT_ADVANCE;
         } else {
-          if (opponent === RED) score += sign * r * WEIGHT_ADVANCE;
-          else score += sign * (BOARD_SIZE - 1 - r) * WEIGHT_ADVANCE;
+          score += sign * (BOARD_SIZE - 1 - r) * WEIGHT_ADVANCE;
         }
       }
 

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -624,7 +624,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver(state) {

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -454,7 +454,6 @@ if (typeof document !== "undefined") {
   const CELL_SIZE = 56;
   const BOARD_PX = CELL_SIZE * BOARD_SIZE;
   const PIECE_RADIUS = 22;
-  const KING_RADIUS = 16;
 
   function initBoard() {
     canvas = document.getElementById("board-canvas");

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -167,7 +167,7 @@ function getAllMoves(board, player) {
     for (let c = 0; c < BOARD_SIZE; c++) {
       if (getOwner(board[r][c]) === player) {
         const caps = getCaptureMoves(board, r, c);
-        for (var i = 0; i < caps.length; i++) {
+        for (let i = 0; i < caps.length; i++) {
           allCaptures.push(caps[i]);
         }
         const sims = getSimpleMoves(board, r, c);
@@ -182,7 +182,7 @@ function getAllMoves(board, player) {
   if (allCaptures.length > 0) {
     // Expand multi-jump: check if each capture can continue
     const expanded = [];
-    for (var i = 0; i < allCaptures.length; i++) {
+    for (let i = 0; i < allCaptures.length; i++) {
       expandChainCaptures(board, allCaptures[i], player, expanded);
     }
     return expanded;
@@ -336,9 +336,9 @@ function alphaBeta(board, depth, alpha, beta, isMaximizing, aiPlayer) {
 
   if (isMaximizing) {
     let maxEval = -Infinity;
-    for (var i = 0; i < moves.length; i++) {
-      var newBoard = applyMove(board, moves[i]);
-      var eval_ = alphaBeta(newBoard, depth - 1, alpha, beta, false, aiPlayer);
+    for (let i = 0; i < moves.length; i++) {
+      const newBoard = applyMove(board, moves[i]);
+      const eval_ = alphaBeta(newBoard, depth - 1, alpha, beta, false, aiPlayer);
       if (eval_ > maxEval) maxEval = eval_;
       if (maxEval > alpha) alpha = maxEval;
       if (beta <= alpha) break;
@@ -346,9 +346,9 @@ function alphaBeta(board, depth, alpha, beta, isMaximizing, aiPlayer) {
     return maxEval;
   } else {
     let minEval = Infinity;
-    for (var i = 0; i < moves.length; i++) {
-      var newBoard = applyMove(board, moves[i]);
-      var eval_ = alphaBeta(newBoard, depth - 1, alpha, beta, true, aiPlayer);
+    for (let i = 0; i < moves.length; i++) {
+      const newBoard = applyMove(board, moves[i]);
+      const eval_ = alphaBeta(newBoard, depth - 1, alpha, beta, true, aiPlayer);
       if (eval_ < minEval) minEval = eval_;
       if (minEval < beta) beta = minEval;
       if (beta <= alpha) break;
@@ -679,24 +679,24 @@ if (typeof document !== "undefined") {
     if (gameState.mode === "online" && gameState.currentPlayer !== localTeam) return;
     // During chain capture, only allow clicking current piece
     if (gameState.multiJumpPiece) {
-      var rect = canvas.getBoundingClientRect();
-      var scaleX = canvas.width / rect.width;
-      var scaleY = canvas.height / rect.height;
-      var px = (e.clientX - rect.left) * scaleX;
-      var py = (e.clientY - rect.top) * scaleY;
-      var col = Math.floor(px / CELL_SIZE);
-      var row = Math.floor(py / CELL_SIZE);
+      const rect = canvas.getBoundingClientRect();
+      const scaleX = canvas.width / rect.width;
+      const scaleY = canvas.height / rect.height;
+      const px = (e.clientX - rect.left) * scaleX;
+      const py = (e.clientY - rect.top) * scaleY;
+      const col = Math.floor(px / CELL_SIZE);
+      const row = Math.floor(py / CELL_SIZE);
       handleMultiJumpClick(row, col);
       return;
     }
 
-    var rect = canvas.getBoundingClientRect();
-    var scaleX = canvas.width / rect.width;
-    var scaleY = canvas.height / rect.height;
-    var px = (e.clientX - rect.left) * scaleX;
-    var py = (e.clientY - rect.top) * scaleY;
-    var col = Math.floor(px / CELL_SIZE);
-    var row = Math.floor(py / CELL_SIZE);
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const px = (e.clientX - rect.left) * scaleX;
+    const py = (e.clientY - rect.top) * scaleY;
+    const col = Math.floor(px / CELL_SIZE);
+    const row = Math.floor(py / CELL_SIZE);
 
     if (!inBounds(row, col)) return;
 
@@ -1174,7 +1174,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -1218,7 +1218,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -730,7 +730,6 @@ if (typeof document !== "undefined") {
       } else {
         updateMessage("无效的目标位置", "error");
       }
-      return;
     }
   }
 

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -167,12 +167,12 @@ function getAllMoves(board, player) {
     for (let c = 0; c < BOARD_SIZE; c++) {
       if (getOwner(board[r][c]) === player) {
         const caps = getCaptureMoves(board, r, c);
-        for (let i = 0; i < caps.length; i++) {
-          allCaptures.push(caps[i]);
+        for (const cap of caps) {
+          allCaptures.push(cap);
         }
         const sims = getSimpleMoves(board, r, c);
-        for (let j = 0; j < sims.length; j++) {
-          allSimple.push(sims[j]);
+        for (const sim of sims) {
+          allSimple.push(sim);
         }
       }
     }
@@ -182,8 +182,8 @@ function getAllMoves(board, player) {
   if (allCaptures.length > 0) {
     // Expand multi-jump: check if each capture can continue
     const expanded = [];
-    for (let i = 0; i < allCaptures.length; i++) {
-      expandChainCaptures(board, allCaptures[i], player, expanded);
+    for (const capture of allCaptures) {
+      expandChainCaptures(board, capture, player, expanded);
     }
     return expanded;
   }
@@ -209,8 +209,8 @@ function expandChainCaptures(board, move, player, result) {
   if (nextCaps.length === 0) {
     result.push(move);
   } else {
-    for (let i = 0; i < nextCaps.length; i++) {
-      expandChainCaptures(newBoard, nextCaps[i], player, result);
+    for (const nextCap of nextCaps) {
+      expandChainCaptures(newBoard, nextCap, player, result);
     }
   }
 }
@@ -307,8 +307,8 @@ function evaluateThreats(board, player) {
     for (let c = 0; c < BOARD_SIZE; c++) {
       if (getOwner(board[r][c]) === opponent) {
         const caps = getCaptureMoves(board, r, c);
-        for (let i = 0; i < caps.length; i++) {
-          const target = board[caps[i].capturedR][caps[i].capturedC];
+        for (const cap of caps) {
+          const target = board[cap.capturedR][cap.capturedC];
           if (getOwner(target) === player) {
             score += WEIGHT_THREATENED * (isKing(target) ? 2.5 : 1);
           }
@@ -336,8 +336,8 @@ function alphaBeta(board, depth, alpha, beta, isMaximizing, aiPlayer) {
 
   if (isMaximizing) {
     let maxEval = -Infinity;
-    for (let i = 0; i < moves.length; i++) {
-      const newBoard = applyMove(board, moves[i]);
+    for (const move of moves) {
+      const newBoard = applyMove(board, move);
       const eval_ = alphaBeta(newBoard, depth - 1, alpha, beta, false, aiPlayer);
       if (eval_ > maxEval) maxEval = eval_;
       if (maxEval > alpha) alpha = maxEval;
@@ -346,8 +346,8 @@ function alphaBeta(board, depth, alpha, beta, isMaximizing, aiPlayer) {
     return maxEval;
   } else {
     let minEval = Infinity;
-    for (let i = 0; i < moves.length; i++) {
-      const newBoard = applyMove(board, moves[i]);
+    for (const move of moves) {
+      const newBoard = applyMove(board, move);
       const eval_ = alphaBeta(newBoard, depth - 1, alpha, beta, true, aiPlayer);
       if (eval_ < minEval) minEval = eval_;
       if (minEval < beta) beta = minEval;
@@ -364,12 +364,12 @@ function getBestAIMove(board, aiPlayer) {
   let bestMove = null;
   let bestScore = -Infinity;
 
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     const score = alphaBeta(newBoard, AI_DEPTH - 1, -Infinity, Infinity, false, aiPlayer);
     if (score > bestScore) {
       bestScore = score;
-      bestMove = moves[i];
+      bestMove = move;
     }
   }
   return bestMove;
@@ -512,8 +512,7 @@ if (typeof document !== "undefined") {
   }
 
   function drawValidMoves(moves) {
-    for (let i = 0; i < moves.length; i++) {
-      const m = moves[i];
+    for (const m of moves) {
       const cx = m.toC * CELL_SIZE + CELL_SIZE / 2;
       const cy = m.toR * CELL_SIZE + CELL_SIZE / 2;
       context.fillStyle = "rgba(76, 175, 80, 0.5)";
@@ -772,8 +771,8 @@ if (typeof document !== "undefined") {
   }
 
   function findMove(moves, toR, toC) {
-    for (let i = 0; i < moves.length; i++) {
-      if (moves[i].toR === toR && moves[i].toC === toC) return moves[i];
+    for (const move of moves) {
+      if (move.toR === toR && move.toC === toC) return move;
     }
     return null;
   }

--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -1162,13 +1162,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
 
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
@@ -1301,7 +1301,7 @@ if (typeof document !== "undefined") {
       button.addEventListener("click", (ev) => {
         const player = ev.target.dataset.player;
         const choice = ev.target.dataset.choice;
-        handleRPSChoice(player, choice);
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -1043,7 +1043,6 @@ if (typeof document !== "undefined") {
   let roomUI = null;
   let localPlayerRole = null; // 'host' | 'guest'
   let localTeam = null; // RED or BLUE
-  let remoteTeam = null; // RED or BLUE
   let pendingBoardSeed = null; // For guest: seed from host for deterministic board
   let onlineTeamsAssigned = false; // Track if teams have been assigned in flip mode
 
@@ -1875,7 +1874,6 @@ if (typeof document !== "undefined") {
     }
     localPlayerRole = null;
     localTeam = null;
-    remoteTeam = null;
     pendingBoardSeed = null;
     onlineTeamsAssigned = false;
   }
@@ -2007,7 +2005,6 @@ if (typeof document !== "undefined") {
       gameState = createGameState({ gameType: gameType, oppType: "online" }, seed);
 
       localTeam = RED;
-      remoteTeam = BLUE;
 
       if (gameType !== "flip") {
         gameState.currentTeam = firstPlayerRole === "host" ? RED : BLUE;
@@ -2025,7 +2022,6 @@ if (typeof document !== "undefined") {
       gameState = createGameState({ gameType: gameType, oppType: "online" }, actualSeed);
 
       localTeam = BLUE;
-      remoteTeam = RED;
 
       if (gameType !== "flip") {
         gameState.currentTeam = firstPlayerRole === "host" ? RED : BLUE;

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -1118,24 +1118,48 @@ if (typeof document !== "undefined") {
     // Horizontal highways
     const hHighwayRows = [0, 2, 3, 4, 7, 8, 9, 11];
     for (const y of hHighwayRows) {
-      addSVGLine(gHighway, ns, svgX(0), svgY(y), svgX(4), svgY(y), "gray", 1);
+      addSVGLine(gHighway, ns, { x1: svgX(0), y1: svgY(y), x2: svgX(4), y2: svgY(y) }, "gray", 1);
     }
     // Vertical highways
     for (let x = 0; x < COLS; x++) {
-      addSVGLine(gHighway, ns, svgX(x), svgY(0), svgX(x), svgY(5), "gray", 1);
-      addSVGLine(gHighway, ns, svgX(x), svgY(6), svgX(x), svgY(11), "gray", 1);
+      addSVGLine(gHighway, ns, { x1: svgX(x), y1: svgY(0), x2: svgX(x), y2: svgY(5) }, "gray", 1);
+      addSVGLine(gHighway, ns, { x1: svgX(x), y1: svgY(6), x2: svgX(x), y2: svgY(11) }, "gray", 1);
     }
 
     // ---- Railways (gold/black striped thick lines) ----
     // Horizontal railways
     const hRailRows = [1, 5, 6, 10];
     for (const y of hRailRows) {
-      addSVGLine(gRailway, ns, svgX(0), svgY(y), svgX(4), svgY(y), "url(#rail-stripe)", 4);
+      addSVGLine(
+        gRailway,
+        ns,
+        { x1: svgX(0), y1: svgY(y), x2: svgX(4), y2: svgY(y) },
+        "url(#rail-stripe)",
+        4
+      );
     }
     // Vertical railways
-    addSVGLine(gRailway, ns, svgX(0), svgY(1), svgX(0), svgY(10), "url(#rail-stripe)", 4);
-    addSVGLine(gRailway, ns, svgX(4), svgY(1), svgX(4), svgY(10), "url(#rail-stripe)", 4);
-    addSVGLine(gRailway, ns, svgX(2), svgY(5), svgX(2), svgY(6), "url(#rail-stripe)", 4);
+    addSVGLine(
+      gRailway,
+      ns,
+      { x1: svgX(0), y1: svgY(1), x2: svgX(0), y2: svgY(10) },
+      "url(#rail-stripe)",
+      4
+    );
+    addSVGLine(
+      gRailway,
+      ns,
+      { x1: svgX(4), y1: svgY(1), x2: svgX(4), y2: svgY(10) },
+      "url(#rail-stripe)",
+      4
+    );
+    addSVGLine(
+      gRailway,
+      ns,
+      { x1: svgX(2), y1: svgY(5), x2: svgX(2), y2: svgY(6) },
+      "url(#rail-stripe)",
+      4
+    );
 
     // ---- Diagonals (gray dashed lines) ----
     const drawn = {};
@@ -1245,12 +1269,12 @@ if (typeof document !== "undefined") {
     updateScale();
   }
 
-  function addSVGLine(parent, ns, x1, y1, x2, y2, stroke, strokeWidth) {
+  function addSVGLine(parent, ns, coords, stroke, strokeWidth) {
     const line = document.createElementNS(ns, "line");
-    line.setAttribute("x1", x1);
-    line.setAttribute("y1", y1);
-    line.setAttribute("x2", x2);
-    line.setAttribute("y2", y2);
+    line.setAttribute("x1", coords.x1);
+    line.setAttribute("y1", coords.y1);
+    line.setAttribute("x2", coords.x2);
+    line.setAttribute("y2", coords.y2);
     line.setAttribute("stroke", stroke);
     line.setAttribute("stroke-width", strokeWidth);
     parent.appendChild(line);

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -683,10 +683,8 @@ function getDiagonalMoves(board, x, y, team) {
           if (target.state === STATE_FACE_DOWN) break;
           if (isFlag(target.name) && piece.name === "工兵") {
             moves.push({ x: cx, y: cy, type: "capture_flag" });
-          } else {
-            if (canCapture(piece, target)) {
-              moves.push({ x: cx, y: cy, type: "capture" });
-            }
+          } else if (canCapture(piece, target)) {
+            moves.push({ x: cx, y: cy, type: "capture" });
           }
           break;
         } else {
@@ -696,20 +694,18 @@ function getDiagonalMoves(board, x, y, team) {
         cx += diagDirs[d].dx;
         cy += diagDirs[d].dy;
       }
-    } else {
+    } else if (isCamp(nx, ny) || isBaseCamp(nx, ny)) {
       // Not in camp: can only enter camp or base camp
-      if (isCamp(nx, ny) || isBaseCamp(nx, ny)) {
-        var target = board[ny][nx];
-        if (target === null) {
-          moves.push({ x: nx, y: ny, type: "move" });
-        } else if (
-          target.team !== team &&
-          target.state !== STATE_FACE_DOWN &&
-          isFlag(target.name) &&
-          piece.name === "工兵"
-        ) {
-          moves.push({ x: nx, y: ny, type: "capture_flag" });
-        }
+      var target = board[ny][nx];
+      if (target === null) {
+        moves.push({ x: nx, y: ny, type: "move" });
+      } else if (
+        target.team !== team &&
+        target.state !== STATE_FACE_DOWN &&
+        isFlag(target.name) &&
+        piece.name === "工兵"
+      ) {
+        moves.push({ x: nx, y: ny, type: "capture_flag" });
       }
     }
   }

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -496,9 +496,9 @@ function getNormalMoves(board, x, y, team) {
     { dx: 1, dy: 0 },
   ];
 
-  for (let d = 0; d < dirs.length; d++) {
-    const nx = x + dirs[d].dx;
-    const ny = y + dirs[d].dy;
+  for (const dir of dirs) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
     if (!inBounds(nx, ny)) continue;
 
     // Gap row crossing: only middle column(x=2) or side vertical railways(x=0,4) can cross
@@ -524,9 +524,9 @@ function getNormalMoves(board, x, y, team) {
 
   // Non-engineer pieces on railway: extra step along railway
   if (isOnRailway(x, y)) {
-    for (let d = 0; d < dirs.length; d++) {
-      const nx = x + dirs[d].dx;
-      const ny = y + dirs[d].dy;
+    for (const dir of dirs) {
+      const nx = x + dir.dx;
+      const ny = y + dir.dy;
       if (!inBounds(nx, ny)) continue;
       if (!areOnSameRailway(x, y, nx, ny)) continue;
 
@@ -570,9 +570,9 @@ function getEngineerMoves(board, x, y, team) {
   ];
 
   // One orthogonal step (to adjacent non-railway cell, like camp)
-  for (let d = 0; d < dirs.length; d++) {
-    const nx = x + dirs[d].dx;
-    const ny = y + dirs[d].dy;
+  for (const dir of dirs) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
     if (!inBounds(nx, ny)) continue;
 
     // Gap row crossing check
@@ -600,9 +600,9 @@ function getEngineerMoves(board, x, y, team) {
 
   while (queue.length > 0) {
     const cur = queue.shift();
-    for (let d = 0; d < dirs.length; d++) {
-      const nx = cur.x + dirs[d].dx;
-      const ny = cur.y + dirs[d].dy;
+    for (const dir of dirs) {
+      const nx = cur.x + dir.dx;
+      const ny = cur.y + dir.dy;
       const key = nx + "," + ny;
       if (visited[key]) continue;
       if (!inBounds(nx, ny)) continue;

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -233,11 +233,11 @@ function createGameState(mode, seed) {
   // Red team 25 pieces
   const redNames = [];
   for (const name in PIECE_COUNTS) {
-    for (var i = 0; i < PIECE_COUNTS[name]; i++) {
+    for (let i = 0; i < PIECE_COUNTS[name]; i++) {
       redNames.push(name);
     }
   }
-  for (var i = 0; i < redNames.length; i++) {
+  for (let i = 0; i < redNames.length; i++) {
     pieces.push({
       name: redNames[i],
       team: RED,
@@ -247,7 +247,7 @@ function createGameState(mode, seed) {
   }
 
   // Blue team 25 pieces
-  for (var i = 0; i < redNames.length; i++) {
+  for (let i = 0; i < redNames.length; i++) {
     pieces.push({
       name: redNames[i],
       team: BLUE,
@@ -258,9 +258,9 @@ function createGameState(mode, seed) {
 
   // Place pieces
   const board = [];
-  for (var y = 0; y < ROWS; y++) {
+  for (let y = 0; y < ROWS; y++) {
     board[y] = [];
-    for (var x = 0; x < COLS; x++) {
+    for (let x = 0; x < COLS; x++) {
       board[y][x] = null;
     }
   }
@@ -275,8 +275,8 @@ function createGameState(mode, seed) {
 
     // Hidden mode: opponent pieces face down
     if (gameType === "hidden") {
-      for (var y = 0; y < ROWS; y++) {
-        for (var x = 0; x < COLS; x++) {
+      for (let y = 0; y < ROWS; y++) {
+        for (let x = 0; x < COLS; x++) {
           const p = board[y][x];
           if (p) p.state = STATE_FACE_DOWN;
         }
@@ -311,7 +311,7 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
   const bombs = [];
   const others = [];
 
-  for (var i = 0; i < pieces.length; i++) {
+  for (let i = 0; i < pieces.length; i++) {
     const p = pieces[i];
     if (isFlag(p.name)) flags.push(p);
     else if (isMine(p.name)) mines.push(p);
@@ -321,8 +321,8 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
 
   // Collect all positions in this half (excluding camps)
   const allPositions = [];
-  for (var y = yStart; y < yStart + 6; y++) {
-    for (var x = 0; x < COLS; x++) {
+  for (let y = yStart; y < yStart + 6; y++) {
+    for (let x = 0; x < COLS; x++) {
       if (!isCamp(x, y)) {
         allPositions.push({ x: x, y: y });
       }
@@ -343,56 +343,56 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
 
   // 1. Place flag: must be in base camp
   const baseCampPositions = [];
-  for (var i = 0; i < BASE_CAMPS.length; i++) {
+  for (let i = 0; i < BASE_CAMPS.length; i++) {
     const bc = BASE_CAMPS[i];
     if (bc.y >= yStart && bc.y < yStart + 6) {
       baseCampPositions.push(bc);
     }
   }
   doShuffle(baseCampPositions);
-  for (var i = 0; i < flags.length; i++) {
-    var pos = baseCampPositions[i];
+  for (let i = 0; i < flags.length; i++) {
+    const pos = baseCampPositions[i];
     board[pos.y][pos.x] = flags[i];
     occupy(pos.x, pos.y);
   }
 
   // 2. Place mines: only in last two rows (excluding camps)
   const mineRows = [];
-  for (var y = yStart + 4; y < yStart + 6; y++) {
-    for (var x = 0; x < COLS; x++) {
+  for (let y = yStart + 4; y < yStart + 6; y++) {
+    for (let x = 0; x < COLS; x++) {
       if (!isCamp(x, y) && !isOccupied(x, y)) mineRows.push({ x: x, y: y });
     }
   }
   doShuffle(mineRows);
-  for (var i = 0; i < mines.length; i++) {
-    var pos = mineRows[i];
+  for (let i = 0; i < mines.length; i++) {
+    const pos = mineRows[i];
     board[pos.y][pos.x] = mines[i];
     occupy(pos.x, pos.y);
   }
 
   // 3. Place bombs: not in first row (excluding camps)
   const bombPositions = [];
-  for (var i = 0; i < allPositions.length; i++) {
-    var pos = allPositions[i];
+  for (let i = 0; i < allPositions.length; i++) {
+    const pos = allPositions[i];
     if (pos.y === yStart) continue; // Exclude first row
     if (!isOccupied(pos.x, pos.y)) bombPositions.push(pos);
   }
   doShuffle(bombPositions);
-  for (var i = 0; i < bombs.length; i++) {
-    var pos = bombPositions[i];
+  for (let i = 0; i < bombs.length; i++) {
+    const pos = bombPositions[i];
     board[pos.y][pos.x] = bombs[i];
     occupy(pos.x, pos.y);
   }
 
   // 4. Place remaining pieces (excluding camps)
   const remaining = [];
-  for (var i = 0; i < allPositions.length; i++) {
-    var pos = allPositions[i];
+  for (let i = 0; i < allPositions.length; i++) {
+    const pos = allPositions[i];
     if (!isOccupied(pos.x, pos.y)) remaining.push(pos);
   }
   doShuffle(remaining);
-  for (var i = 0; i < others.length; i++) {
-    var pos = remaining[i];
+  for (let i = 0; i < others.length; i++) {
+    const pos = remaining[i];
     board[pos.y][pos.x] = others[i];
     occupy(pos.x, pos.y);
   }
@@ -412,12 +412,12 @@ function placePiecesRandom(board, pieces, rng) {
   else shuffle(allPositions);
 
   // All pieces face down
-  for (var i = 0; i < pieces.length; i++) {
+  for (let i = 0; i < pieces.length; i++) {
     pieces[i].state = STATE_FACE_DOWN;
   }
 
   // Place randomly
-  for (var i = 0; i < pieces.length; i++) {
+  for (let i = 0; i < pieces.length; i++) {
     const pos = allPositions[i];
     board[pos.y][pos.x] = pieces[i];
   }
@@ -501,9 +501,9 @@ function getNormalMoves(board, x, y, team) {
     { dx: 1, dy: 0 },
   ];
 
-  for (var d = 0; d < dirs.length; d++) {
-    var nx = x + dirs[d].dx;
-    var ny = y + dirs[d].dy;
+  for (let d = 0; d < dirs.length; d++) {
+    const nx = x + dirs[d].dx;
+    const ny = y + dirs[d].dy;
     if (!inBounds(nx, ny)) continue;
 
     // Gap row crossing: only middle column(x=2) or side vertical railways(x=0,4) can cross
@@ -512,7 +512,7 @@ function getNormalMoves(board, x, y, team) {
     }
 
     // Normal piece can move one step to adjacent position
-    var target = board[ny][nx];
+    const target = board[ny][nx];
     if (target === null) {
       moves.push({ x: nx, y: ny, type: "move" });
     } else if (target.team !== team) {
@@ -529,9 +529,9 @@ function getNormalMoves(board, x, y, team) {
 
   // Non-engineer pieces on railway: extra step along railway
   if (isOnRailway(x, y)) {
-    for (var d = 0; d < dirs.length; d++) {
-      var nx = x + dirs[d].dx;
-      var ny = y + dirs[d].dy;
+    for (let d = 0; d < dirs.length; d++) {
+      const nx = x + dirs[d].dx;
+      const ny = y + dirs[d].dy;
       if (!inBounds(nx, ny)) continue;
       if (!areOnSameRailway(x, y, nx, ny)) continue;
 
@@ -545,7 +545,7 @@ function getNormalMoves(board, x, y, team) {
       }
       if (dup) continue;
 
-      var target = board[ny][nx];
+      const target = board[ny][nx];
       if (target === null) {
         moves.push({ x: nx, y: ny, type: "move" });
       } else if (target.team !== team) {
@@ -575,9 +575,9 @@ function getEngineerMoves(board, x, y, team) {
   ];
 
   // One orthogonal step (to adjacent non-railway cell, like camp)
-  for (var d = 0; d < dirs.length; d++) {
-    var nx = x + dirs[d].dx;
-    var ny = y + dirs[d].dy;
+  for (let d = 0; d < dirs.length; d++) {
+    const nx = x + dirs[d].dx;
+    const ny = y + dirs[d].dy;
     if (!inBounds(nx, ny)) continue;
 
     // Gap row crossing check
@@ -588,9 +588,9 @@ function getEngineerMoves(board, x, y, team) {
     // Skip railway cells, leave for BFS
     if (isOnRailway(nx, ny)) continue;
 
-    var key = nx + "," + ny;
+    const key = nx + "," + ny;
     if (visited[key]) continue;
-    var target = board[ny][nx];
+    const target = board[ny][nx];
     if (target === null) {
       moves.push({ x: nx, y: ny, type: "move" });
     } else if (target.team !== team) {
@@ -605,10 +605,10 @@ function getEngineerMoves(board, x, y, team) {
 
   while (queue.length > 0) {
     const cur = queue.shift();
-    for (var d = 0; d < dirs.length; d++) {
-      var nx = cur.x + dirs[d].dx;
-      var ny = cur.y + dirs[d].dy;
-      var key = nx + "," + ny;
+    for (let d = 0; d < dirs.length; d++) {
+      const nx = cur.x + dirs[d].dx;
+      const ny = cur.y + dirs[d].dy;
+      const key = nx + "," + ny;
       if (visited[key]) continue;
       if (!inBounds(nx, ny)) continue;
 
@@ -616,7 +616,7 @@ function getEngineerMoves(board, x, y, team) {
       if (!areOnSameRailway(cur.x, cur.y, nx, ny)) continue;
 
       visited[key] = true;
-      var target = board[ny][nx];
+      const target = board[ny][nx];
       if (target === null) {
         moves.push({ x: nx, y: ny, type: "move" });
         queue.push({ x: nx, y: ny });
@@ -666,7 +666,7 @@ function getDiagonalMoves(board, x, y, team) {
       let cx = x + diagDirs[d].dx;
       let cy = y + diagDirs[d].dy;
       while (inBounds(cx, cy)) {
-        var target = board[cy][cx];
+        const target = board[cy][cx];
         if (isCamp(cx, cy)) {
           // Reached another camp
           if (target === null) {
@@ -696,7 +696,7 @@ function getDiagonalMoves(board, x, y, team) {
       }
     } else if (isCamp(nx, ny) || isBaseCamp(nx, ny)) {
       // Not in camp: can only enter camp or base camp
-      var target = board[ny][nx];
+      const target = board[ny][nx];
       if (target === null) {
         moves.push({ x: nx, y: ny, type: "move" });
       } else if (
@@ -869,8 +869,8 @@ function aiDecide(state, aiTeam) {
   // Flip mode: prioritize flipping pieces
   if (gameType === "flip") {
     const faceDown = [];
-    for (var y = 0; y < ROWS; y++) {
-      for (var x = 0; x < COLS; x++) {
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
         const p = board[y][x];
         if (p && p.state === STATE_FACE_DOWN) {
           faceDown.push({ x: x, y: y });
@@ -879,19 +879,19 @@ function aiDecide(state, aiTeam) {
     }
     if (faceDown.length > 0) {
       // Prioritize flipping near own pieces, or flip randomly
-      var pick = faceDown[Math.floor(Math.random() * faceDown.length)];
+      const pick = faceDown[Math.floor(Math.random() * faceDown.length)];
       return { type: "flip", from: { x: pick.x, y: pick.y }, to: { x: pick.x, y: pick.y } };
     }
   }
 
   // Priority 1: engineer captures flag
-  for (var y = 0; y < ROWS; y++) {
-    for (var x = 0; x < COLS; x++) {
-      var piece = board[y][x];
+  for (let y = 0; y < ROWS; y++) {
+    for (let x = 0; x < COLS; x++) {
+      const piece = board[y][x];
       if (!piece || piece.team !== aiTeam || piece.name !== "工兵") continue;
       if (piece.state === STATE_FACE_DOWN) continue;
-      var moves = getValidMoves(board, x, y, aiTeam, gameType);
-      for (var i = 0; i < moves.length; i++) {
+      const moves = getValidMoves(board, x, y, aiTeam, gameType);
+      for (let i = 0; i < moves.length; i++) {
         if (moves[i].type === "capture_flag") {
           return { type: "move", from: { x: x, y: y }, to: { x: moves[i].x, y: moves[i].y } };
         }
@@ -902,13 +902,13 @@ function aiDecide(state, aiTeam) {
   // Priority 2: favorable captures
   let bestCapture = null;
   let bestScore = -999;
-  for (var y = 0; y < ROWS; y++) {
-    for (var x = 0; x < COLS; x++) {
-      var piece = board[y][x];
+  for (let y = 0; y < ROWS; y++) {
+    for (let x = 0; x < COLS; x++) {
+      const piece = board[y][x];
       if (!piece || piece.team !== aiTeam || !isMovable(piece)) continue;
       if (piece.state === STATE_FACE_DOWN) continue;
-      var moves = getValidMoves(board, x, y, aiTeam, gameType);
-      for (var i = 0; i < moves.length; i++) {
+      const moves = getValidMoves(board, x, y, aiTeam, gameType);
+      for (let i = 0; i < moves.length; i++) {
         if (moves[i].type !== "capture") continue;
         const target = board[moves[i].y][moves[i].x];
         if (target.state === STATE_FACE_DOWN) continue;
@@ -933,13 +933,13 @@ function aiDecide(state, aiTeam) {
 
   // Priority 3: normal moves
   const allMoves = [];
-  for (var y = 0; y < ROWS; y++) {
-    for (var x = 0; x < COLS; x++) {
-      var piece = board[y][x];
+  for (let y = 0; y < ROWS; y++) {
+    for (let x = 0; x < COLS; x++) {
+      const piece = board[y][x];
       if (!piece || piece.team !== aiTeam || !isMovable(piece)) continue;
       if (piece.state === STATE_FACE_DOWN) continue;
-      var moves = getValidMoves(board, x, y, aiTeam, gameType);
-      for (var i = 0; i < moves.length; i++) {
+      const moves = getValidMoves(board, x, y, aiTeam, gameType);
+      for (let i = 0; i < moves.length; i++) {
         if (moves[i].type === "move") {
           allMoves.push({ from: { x: x, y: y }, to: { x: moves[i].x, y: moves[i].y } });
         }
@@ -949,7 +949,7 @@ function aiDecide(state, aiTeam) {
   // Railway moves preferred
   const railwayMoves = [];
   const normalMoves = [];
-  for (var i = 0; i < allMoves.length; i++) {
+  for (let i = 0; i < allMoves.length; i++) {
     if (isOnRailway(allMoves[i].from.x, allMoves[i].from.y)) {
       railwayMoves.push(allMoves[i]);
     } else {
@@ -959,7 +959,7 @@ function aiDecide(state, aiTeam) {
   let pool = railwayMoves.length > 0 ? railwayMoves : normalMoves;
   if (pool.length === 0) pool = allMoves;
   if (pool.length > 0) {
-    var pick = pool[Math.floor(Math.random() * pool.length)];
+    const pick = pool[Math.floor(Math.random() * pool.length)];
     return { type: "move", from: pick.from, to: pick.to };
   }
 
@@ -1122,12 +1122,12 @@ if (typeof document !== "undefined") {
     // ---- Highways (gray thin lines) ----
     // Horizontal highways
     const hHighwayRows = [0, 2, 3, 4, 7, 8, 9, 11];
-    for (var i = 0; i < hHighwayRows.length; i++) {
-      var y = hHighwayRows[i];
+    for (let i = 0; i < hHighwayRows.length; i++) {
+      const y = hHighwayRows[i];
       addSVGLine(gHighway, ns, svgX(0), svgY(y), svgX(4), svgY(y), "gray", 1);
     }
     // Vertical highways
-    for (var x = 0; x < COLS; x++) {
+    for (let x = 0; x < COLS; x++) {
       addSVGLine(gHighway, ns, svgX(x), svgY(0), svgX(x), svgY(5), "gray", 1);
       addSVGLine(gHighway, ns, svgX(x), svgY(6), svgX(x), svgY(11), "gray", 1);
     }
@@ -1135,8 +1135,8 @@ if (typeof document !== "undefined") {
     // ---- Railways (gold/black striped thick lines) ----
     // Horizontal railways
     const hRailRows = [1, 5, 6, 10];
-    for (var i = 0; i < hRailRows.length; i++) {
-      var y = hRailRows[i];
+    for (let i = 0; i < hRailRows.length; i++) {
+      const y = hRailRows[i];
       addSVGLine(gRailway, ns, svgX(0), svgY(y), svgX(4), svgY(y), "url(#rail-stripe)", 4);
     }
     // Vertical railways
@@ -1146,8 +1146,8 @@ if (typeof document !== "undefined") {
 
     // ---- Diagonals (gray dashed lines) ----
     const drawn = {};
-    for (var y = 0; y < ROWS; y++) {
-      for (var x = 0; x < COLS; x++) {
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
         if (!hasDiagonalEligibility(x, y) && !isCamp(x, y)) continue;
         const diagDirs = [
           { dx: -1, dy: -1 },
@@ -1183,8 +1183,8 @@ if (typeof document !== "undefined") {
     const CAMP_RX = 38;
     const CAMP_RY = 28;
 
-    for (var y = 0; y < ROWS; y++) {
-      for (var x = 0; x < COLS; x++) {
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
         const cx = svgX(x),
           cy = svgY(y);
         let label = "兵 站";
@@ -1337,9 +1337,9 @@ if (typeof document !== "undefined") {
 
     // Remove old highlights
     const old = layer.querySelectorAll(".move-highlight");
-    for (var i = 0; i < old.length; i++) old[i].remove();
+    for (let i = 0; i < old.length; i++) old[i].remove();
 
-    for (var i = 0; i < moves.length; i++) {
+    for (let i = 0; i < moves.length; i++) {
       const m = moves[i];
       const div = document.createElement("div");
       div.className = "move-highlight";
@@ -1391,7 +1391,7 @@ if (typeof document !== "undefined") {
 
     // Flip mode: click face-down piece to flip
     if (gameType === "flip" && piece && piece.state === STATE_FACE_DOWN) {
-      var result = flipPiece(gameState, x, y);
+      const result = flipPiece(gameState, x, y);
       if (result) {
         sendNetworkAction({ type: "flip", x: x, y: y });
         clearHighlights();
@@ -1404,8 +1404,8 @@ if (typeof document !== "undefined") {
     // Click highlight target (move/capture)
     if (target.classList.contains("move-highlight")) {
       if (gameState.selectedCell) {
-        var sel = gameState.selectedCell;
-        var result = moveCard(gameState, sel, { x: x, y: y });
+        const sel = gameState.selectedCell;
+        const result = moveCard(gameState, sel, { x: x, y: y });
         if (result) {
           sendNetworkAction({ type: "move", fx: sel.x, fy: sel.y, tx: x, ty: y });
           gameState.selectedCell = null;
@@ -1419,7 +1419,7 @@ if (typeof document !== "undefined") {
 
     // Already has selected piece
     if (gameState.selectedCell) {
-      var sel = gameState.selectedCell;
+      const sel = gameState.selectedCell;
 
       // Click same cell: deselect
       if (sel.x === x && sel.y === y) {
@@ -1430,7 +1430,7 @@ if (typeof document !== "undefined") {
       }
 
       // Try move/capture
-      var result = moveCard(gameState, sel, { x: x, y: y });
+      const result = moveCard(gameState, sel, { x: x, y: y });
       if (result) {
         sendNetworkAction({ type: "move", fx: sel.x, fy: sel.y, tx: x, ty: y });
         gameState.selectedCell = null;
@@ -1445,7 +1445,7 @@ if (typeof document !== "undefined") {
         gameState.selectedCell = { x: x, y: y };
         clearHighlights();
         drawBoard();
-        var moves = getValidMoves(gameState.board, x, y, team, gameType);
+        const moves = getValidMoves(gameState.board, x, y, team, gameType);
         highlightMoves(moves);
         return;
       }
@@ -1459,7 +1459,7 @@ if (typeof document !== "undefined") {
       gameState.selectedCell = { x: x, y: y };
       clearHighlights();
       drawBoard();
-      var moves = getValidMoves(gameState.board, x, y, team, gameType);
+      const moves = getValidMoves(gameState.board, x, y, team, gameType);
       highlightMoves(moves);
       return;
     }
@@ -1775,7 +1775,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -1819,7 +1819,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -123,15 +123,15 @@ function inBounds(x, y) {
 }
 
 function isCamp(x, y) {
-  for (let i = 0; i < CAMPS.length; i++) {
-    if (CAMPS[i].x === x && CAMPS[i].y === y) return true;
+  for (const camp of CAMPS) {
+    if (camp.x === x && camp.y === y) return true;
   }
   return false;
 }
 
 function isBaseCamp(x, y) {
-  for (let i = 0; i < BASE_CAMPS.length; i++) {
-    if (BASE_CAMPS[i].x === x && BASE_CAMPS[i].y === y) return true;
+  for (const baseCamp of BASE_CAMPS) {
+    if (baseCamp.x === x && baseCamp.y === y) return true;
   }
   return false;
 }
@@ -232,26 +232,26 @@ function createGameState(mode, seed) {
 
   // Red team 25 pieces
   const redNames = [];
-  for (const name in PIECE_COUNTS) {
+  for (const name of Object.keys(PIECE_COUNTS)) {
     for (let i = 0; i < PIECE_COUNTS[name]; i++) {
       redNames.push(name);
     }
   }
-  for (let i = 0; i < redNames.length; i++) {
+  for (const name of redNames) {
     pieces.push({
-      name: redNames[i],
+      name: name,
       team: RED,
-      rank: getRank(redNames[i]),
+      rank: getRank(name),
       state: STATE_FACE_UP,
     });
   }
 
   // Blue team 25 pieces
-  for (let i = 0; i < redNames.length; i++) {
+  for (const name of redNames) {
     pieces.push({
-      name: redNames[i],
+      name: name,
       team: BLUE,
-      rank: getRank(redNames[i]),
+      rank: getRank(name),
       state: STATE_FACE_UP,
     });
   }
@@ -311,8 +311,7 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
   const bombs = [];
   const others = [];
 
-  for (let i = 0; i < pieces.length; i++) {
-    const p = pieces[i];
+  for (const p of pieces) {
     if (isFlag(p.name)) flags.push(p);
     else if (isMine(p.name)) mines.push(p);
     else if (isBomb(p.name)) bombs.push(p);
@@ -343,8 +342,7 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
 
   // 1. Place flag: must be in base camp
   const baseCampPositions = [];
-  for (let i = 0; i < BASE_CAMPS.length; i++) {
-    const bc = BASE_CAMPS[i];
+  for (const bc of BASE_CAMPS) {
     if (bc.y >= yStart && bc.y < yStart + 6) {
       baseCampPositions.push(bc);
     }
@@ -372,8 +370,7 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
 
   // 3. Place bombs: not in first row (excluding camps)
   const bombPositions = [];
-  for (let i = 0; i < allPositions.length; i++) {
-    const pos = allPositions[i];
+  for (const pos of allPositions) {
     if (pos.y === yStart) continue; // Exclude first row
     if (!isOccupied(pos.x, pos.y)) bombPositions.push(pos);
   }
@@ -386,8 +383,7 @@ function placePiecesForTeam(board, pieces, halfIndex, rng) {
 
   // 4. Place remaining pieces (excluding camps)
   const remaining = [];
-  for (let i = 0; i < allPositions.length; i++) {
-    const pos = allPositions[i];
+  for (const pos of allPositions) {
     if (!isOccupied(pos.x, pos.y)) remaining.push(pos);
   }
   doShuffle(remaining);
@@ -412,8 +408,8 @@ function placePiecesRandom(board, pieces, rng) {
   else shuffle(allPositions);
 
   // All pieces face down
-  for (let i = 0; i < pieces.length; i++) {
-    pieces[i].state = STATE_FACE_DOWN;
+  for (const piece of pieces) {
+    piece.state = STATE_FACE_DOWN;
   }
 
   // Place randomly
@@ -477,8 +473,7 @@ function getValidMoves(board, x, y, team, gameType) {
 
   // Add diagonal moves (camp entry/exit)
   const diagMoves = getDiagonalMoves(board, x, y, team);
-  for (let i = 0; i < diagMoves.length; i++) {
-    const dm = diagMoves[i];
+  for (const dm of diagMoves) {
     let dup = false;
     for (let j = 0; j < moves.length; j++) {
       if (moves[j].x === dm.x && moves[j].y === dm.y) {
@@ -724,9 +719,9 @@ function moveCard(state, from, to) {
 
   const validMoves = getValidMoves(state.board, from.x, from.y, state.currentTeam);
   let valid = null;
-  for (let i = 0; i < validMoves.length; i++) {
-    if (validMoves[i].x === to.x && validMoves[i].y === to.y) {
-      valid = validMoves[i];
+  for (const vm of validMoves) {
+    if (vm.x === to.x && vm.y === to.y) {
+      valid = vm;
       break;
     }
   }
@@ -891,9 +886,9 @@ function aiDecide(state, aiTeam) {
       if (!piece || piece.team !== aiTeam || piece.name !== "工兵") continue;
       if (piece.state === STATE_FACE_DOWN) continue;
       const moves = getValidMoves(board, x, y, aiTeam, gameType);
-      for (let i = 0; i < moves.length; i++) {
-        if (moves[i].type === "capture_flag") {
-          return { type: "move", from: { x: x, y: y }, to: { x: moves[i].x, y: moves[i].y } };
+      for (const m of moves) {
+        if (m.type === "capture_flag") {
+          return { type: "move", from: { x: x, y: y }, to: { x: m.x, y: m.y } };
         }
       }
     }
@@ -908,9 +903,9 @@ function aiDecide(state, aiTeam) {
       if (!piece || piece.team !== aiTeam || !isMovable(piece)) continue;
       if (piece.state === STATE_FACE_DOWN) continue;
       const moves = getValidMoves(board, x, y, aiTeam, gameType);
-      for (let i = 0; i < moves.length; i++) {
-        if (moves[i].type !== "capture") continue;
-        const target = board[moves[i].y][moves[i].x];
+      for (const m of moves) {
+        if (m.type !== "capture") continue;
+        const target = board[m.y][m.x];
         if (target.state === STATE_FACE_DOWN) continue;
         const result = resolveCombat(piece, target);
         let score = 0;
@@ -922,7 +917,7 @@ function aiDecide(state, aiTeam) {
         }
         if (score > bestScore) {
           bestScore = score;
-          bestCapture = { from: { x: x, y: y }, to: { x: moves[i].x, y: moves[i].y } };
+          bestCapture = { from: { x: x, y: y }, to: { x: m.x, y: m.y } };
         }
       }
     }
@@ -939,9 +934,9 @@ function aiDecide(state, aiTeam) {
       if (!piece || piece.team !== aiTeam || !isMovable(piece)) continue;
       if (piece.state === STATE_FACE_DOWN) continue;
       const moves = getValidMoves(board, x, y, aiTeam, gameType);
-      for (let i = 0; i < moves.length; i++) {
-        if (moves[i].type === "move") {
-          allMoves.push({ from: { x: x, y: y }, to: { x: moves[i].x, y: moves[i].y } });
+      for (const m of moves) {
+        if (m.type === "move") {
+          allMoves.push({ from: { x: x, y: y }, to: { x: m.x, y: m.y } });
         }
       }
     }
@@ -949,11 +944,11 @@ function aiDecide(state, aiTeam) {
   // Railway moves preferred
   const railwayMoves = [];
   const normalMoves = [];
-  for (let i = 0; i < allMoves.length; i++) {
-    if (isOnRailway(allMoves[i].from.x, allMoves[i].from.y)) {
-      railwayMoves.push(allMoves[i]);
+  for (const m of allMoves) {
+    if (isOnRailway(m.from.x, m.from.y)) {
+      railwayMoves.push(m);
     } else {
-      normalMoves.push(allMoves[i]);
+      normalMoves.push(m);
     }
   }
   let pool = railwayMoves.length > 0 ? railwayMoves : normalMoves;
@@ -1122,8 +1117,7 @@ if (typeof document !== "undefined") {
     // ---- Highways (gray thin lines) ----
     // Horizontal highways
     const hHighwayRows = [0, 2, 3, 4, 7, 8, 9, 11];
-    for (let i = 0; i < hHighwayRows.length; i++) {
-      const y = hHighwayRows[i];
+    for (const y of hHighwayRows) {
       addSVGLine(gHighway, ns, svgX(0), svgY(y), svgX(4), svgY(y), "gray", 1);
     }
     // Vertical highways
@@ -1135,8 +1129,7 @@ if (typeof document !== "undefined") {
     // ---- Railways (gold/black striped thick lines) ----
     // Horizontal railways
     const hRailRows = [1, 5, 6, 10];
-    for (let i = 0; i < hRailRows.length; i++) {
-      const y = hRailRows[i];
+    for (const y of hRailRows) {
       addSVGLine(gRailway, ns, svgX(0), svgY(y), svgX(4), svgY(y), "url(#rail-stripe)", 4);
     }
     // Vertical railways
@@ -1337,10 +1330,9 @@ if (typeof document !== "undefined") {
 
     // Remove old highlights
     const old = layer.querySelectorAll(".move-highlight");
-    for (let i = 0; i < old.length; i++) old[i].remove();
+    for (const el of old) el.remove();
 
-    for (let i = 0; i < moves.length; i++) {
-      const m = moves[i];
+    for (const m of moves) {
       const div = document.createElement("div");
       div.className = "move-highlight";
       if (m.type === "capture" || m.type === "capture_flag") {
@@ -1362,7 +1354,7 @@ if (typeof document !== "undefined") {
     const layer = document.getElementById("pieces-layer");
     if (!layer) return;
     const old = layer.querySelectorAll(".move-highlight");
-    for (let i = 0; i < old.length; i++) old[i].remove();
+    for (const el of old) el.remove();
     // Remove selection state
     const selDiv = layer.querySelector(".chess-selected");
     if (selDiv) selDiv.classList.remove("chess-selected");
@@ -1529,10 +1521,10 @@ if (typeof document !== "undefined") {
 
   function renderCaptured(container, list, team) {
     container.innerHTML = "";
-    for (let i = 0; i < list.length; i++) {
+    for (const item of list) {
       const span = document.createElement("span");
       span.className = "captured-piece " + (team === RED ? "red-text" : "blue-text");
-      span.textContent = list[i];
+      span.textContent = item;
       container.appendChild(span);
     }
   }

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -97,7 +97,7 @@ const V_RAILWAY_MIDDLE = { x: 2, yMin: 5, yMax: 6 };
 // ============================================================
 
 function isNormalPiece(name) {
-  return NORMAL_PIECE_NAMES.indexOf(name) !== -1;
+  return NORMAL_PIECE_NAMES.includes(name);
 }
 
 function isBomb(name) {
@@ -150,7 +150,7 @@ function hasDiagonalEligibility(x, y) {
 
 // Check if on railway
 function isOnHRailway(y) {
-  return H_RAILWAYS.indexOf(y) !== -1;
+  return H_RAILWAYS.includes(y);
 }
 
 function isOnVRailway(x, y) {

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -575,7 +575,7 @@ if (typeof document !== "undefined") {
   // Determine which color zone a position belongs to - only color start positions
   function getAreaColor(cell) {
     for (let p = 1; p <= 6; p++) {
-      if (START_POSITIONS[p].indexOf(cell) !== -1) {
+      if (START_POSITIONS[p].includes(cell)) {
         return PLAYER_COLORS[p].color;
       }
     }
@@ -647,7 +647,7 @@ if (typeof document !== "undefined") {
       hex.setAttribute("fill", areaColor);
       hex.setAttribute("stroke", "#333");
       hex.setAttribute("stroke-width", "1");
-      hex.setAttribute("data-cell", cell);
+      hex.dataset.cell = cell;
       hex.style.cursor = "pointer";
       g.appendChild(hex);
 
@@ -658,7 +658,7 @@ if (typeof document !== "undefined") {
       inner.setAttribute("r", CELL_SIZE * 0.32);
       inner.setAttribute("fill", "white");
       inner.setAttribute("stroke", "none");
-      inner.setAttribute("data-cell", cell);
+      inner.dataset.cell = cell;
       inner.style.cursor = "pointer";
       g.appendChild(inner);
     }
@@ -682,7 +682,7 @@ if (typeof document !== "undefined") {
         indicator.setAttribute("fill", "#4CAF50");
         indicator.setAttribute("opacity", "0.8");
         indicator.setAttribute("class", "valid-move");
-        indicator.setAttribute("data-cell", moveCell);
+        indicator.dataset.cell = moveCell;
         indicator.style.cursor = "pointer";
         g.appendChild(indicator);
       }
@@ -699,7 +699,7 @@ if (typeof document !== "undefined") {
     piece.setAttribute("stroke", "#333");
     piece.setAttribute("stroke-width", "2");
     piece.setAttribute("class", "piece");
-    piece.setAttribute("data-cell", cell);
+    piece.dataset.cell = cell;
 
     if (gameState.selectedPiece === cell) {
       piece.classList.add("selected");
@@ -769,7 +769,7 @@ if (typeof document !== "undefined") {
     if (gameState.mode === "online" && gameState.currentPlayer !== localTeam) return;
 
     const target = e.target;
-    const cell = Number.parseInt(target.getAttribute("data-cell"));
+    const cell = Number.parseInt(target.dataset.cell);
     if (Number.isNaN(cell)) return;
 
     if (target.classList.contains("piece")) {
@@ -795,7 +795,7 @@ if (typeof document !== "undefined") {
         gameState.validMoves = getLegalMoves(gameState.board, cell);
         drawBoard();
         updateMessage("已选择棋子，点击绿色位置移动", "info");
-      } else if (gameState.selectedPiece !== null && gameState.validMoves.indexOf(cell) !== -1) {
+      } else if (gameState.selectedPiece !== null && gameState.validMoves.includes(cell)) {
         const fromCell = gameState.selectedPiece;
         doMove(fromCell, cell);
         if (gameState.mode === "online" && networkProtocol) {

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -734,7 +734,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver() {

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -1200,13 +1200,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
 
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
@@ -1396,7 +1396,7 @@ if (typeof document !== "undefined") {
       button.addEventListener("click", (ev) => {
         const player = ev.target.dataset.player;
         const choice = ev.target.dataset.choice;
-        handleRPSChoice(player, choice);
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -802,13 +802,11 @@ if (typeof document !== "undefined") {
           networkProtocol.sendAction({ a: "move", from: fromCell, to: cell });
         }
       }
-    } else {
-      if (gameState.selectedPiece !== null) {
-        gameState.selectedPiece = null;
-        gameState.validMoves = [];
-        drawBoard();
-        updateMessage("请选择要移动的棋子", "info");
-      }
+    } else if (gameState.selectedPiece !== null) {
+      gameState.selectedPiece = null;
+      gameState.validMoves = [];
+      drawBoard();
+      updateMessage("请选择要移动的棋子", "info");
     }
   }
 

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -435,16 +435,6 @@ function evaluateMove(board, player, from, to, allPlayers) {
   }
 
   // Factor 5: Blocking opponents
-  const opponents = [];
-  if (allPlayers) {
-    for (let i = 0; i < allPlayers.length; i++) {
-      if (allPlayers[i] !== player) opponents.push(allPlayers[i]);
-    }
-  } else {
-    for (let p = RED; p <= ORANGE; p++) {
-      if (p !== player) opponents.push(p);
-    }
-  }
   const blockingScore = calculateBlockingScore(board, player, to);
   score += blockingScore * AI_WEIGHTS.BLOCKING;
 

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -214,16 +214,16 @@ function initPositionScores() {
     POSITION_SCORES[player] = [];
     const targets = TARGET_POSITIONS[player];
     const targetSet = {};
-    for (let i = 0; i < targets.length; i++) {
-      targetSet[targets[i]] = true;
+    for (const t of targets) {
+      targetSet[t] = true;
     }
 
     // Calculate target area centroid
     let cx = 0,
       cy = 0;
-    for (let i = 0; i < targets.length; i++) {
-      cx += positions[targets[i]].x;
-      cy += positions[targets[i]].y;
+    for (const t of targets) {
+      cx += positions[t].x;
+      cy += positions[t].y;
     }
     cx /= targets.length;
     cy /= targets.length;
@@ -231,13 +231,13 @@ function initPositionScores() {
     // Calculate target area depth reference point (farthest vertex)
     let maxDistFromCenter = 0;
     let tipIdx = targets[0];
-    for (let i = 0; i < targets.length; i++) {
-      const dx = positions[targets[i]].x - cx;
-      const dy = positions[targets[i]].y - cy;
+    for (const t of targets) {
+      const dx = positions[t].x - cx;
+      const dy = positions[t].y - cy;
       const dist = Math.abs(dx) + Math.abs(dy);
       if (dist > maxDistFromCenter) {
         maxDistFromCenter = dist;
-        tipIdx = targets[i];
+        tipIdx = t;
       }
     }
     const tipPos = positions[tipIdx];
@@ -273,17 +273,17 @@ function createBoard() {
 
 function placePieces(board, player) {
   const pos = START_POSITIONS[player];
-  for (let i = 0; i < pos.length; i++) {
-    board[pos[i]] = player;
+  for (const p of pos) {
+    board[p] = player;
   }
 }
 
 function getAdjacentMoves(board, cell) {
   const moves = [];
   const neighbors = ADJACENT[cell];
-  for (let i = 0; i < neighbors.length; i++) {
-    if (board[neighbors[i]] === EMPTY) {
-      moves.push(neighbors[i]);
+  for (const n of neighbors) {
+    if (board[n] === EMPTY) {
+      moves.push(n);
     }
   }
   return moves;
@@ -293,8 +293,7 @@ function getJumpMoves(board, cell, visited) {
   let moves = [];
   const neighbors = ADJACENT[cell];
 
-  for (let i = 0; i < neighbors.length; i++) {
-    const mid = neighbors[i];
+  for (const mid of neighbors) {
     if (board[mid] !== EMPTY) {
       const p1 = positions[cell];
       const p2 = positions[mid];
@@ -322,8 +321,8 @@ function getLegalMoves(board, cell) {
   moves = moves.concat(adjacentMoves);
 
   const visited = {};
-  for (let i = 0; i < adjacentMoves.length; i++) {
-    visited[adjacentMoves[i]] = true;
+  for (const am of adjacentMoves) {
+    visited[am] = true;
   }
   const jumpMoves = getJumpMoves(board, cell, visited);
   moves = moves.concat(jumpMoves);
@@ -345,8 +344,8 @@ function makeMove(board, from, to) {
 
 function checkWin(board, player) {
   const targets = TARGET_POSITIONS[player];
-  for (let i = 0; i < targets.length; i++) {
-    if (board[targets[i]] !== player) {
+  for (const t of targets) {
+    if (board[t] !== player) {
       return false;
     }
   }
@@ -354,9 +353,9 @@ function checkWin(board, player) {
 }
 
 function checkGameOver(board, players) {
-  for (let i = 0; i < players.length; i++) {
-    if (checkWin(board, players[i])) {
-      return players[i];
+  for (const player of players) {
+    if (checkWin(board, player)) {
+      return player;
     }
   }
   return null;
@@ -368,8 +367,8 @@ function checkGameOver(board, players) {
 
 function isInTargetArea(cell, player) {
   const targets = TARGET_POSITIONS[player];
-  for (let i = 0; i < targets.length; i++) {
-    if (targets[i] === cell) return true;
+  for (const t of targets) {
+    if (t === cell) return true;
   }
   return false;
 }
@@ -377,8 +376,7 @@ function isInTargetArea(cell, player) {
 function calculateBlockingScore(board, player, position) {
   let score = 0;
   const neighbors = ADJACENT[position];
-  for (let i = 0; i < neighbors.length; i++) {
-    const neighborCell = neighbors[i];
+  for (const neighborCell of neighbors) {
     if (board[neighborCell] !== EMPTY && board[neighborCell] !== player) {
       // Opponent piece next to target position, forming a block
       const opponent = board[neighborCell];
@@ -393,8 +391,8 @@ function calculateBlockingScore(board, player, position) {
 function calculateFormationScore(board, player, position) {
   let score = 0;
   const neighbors = ADJACENT[position];
-  for (let i = 0; i < neighbors.length; i++) {
-    if (board[neighbors[i]] === player) {
+  for (const n of neighbors) {
+    if (board[n] === player) {
       score += 1;
     }
   }
@@ -457,11 +455,11 @@ function getBestAIMove(board, player, allPlayers) {
   for (let cell = 0; cell < TOTAL_POSITIONS; cell++) {
     if (board[cell] === player) {
       const moves = getLegalMoves(board, cell);
-      for (let i = 0; i < moves.length; i++) {
-        const score = evaluateMove(board, player, cell, moves[i], allPlayers);
+      for (const m of moves) {
+        const score = evaluateMove(board, player, cell, m, allPlayers);
         if (score > bestScore) {
           bestScore = score;
-          bestMove = { from: cell, to: moves[i] };
+          bestMove = { from: cell, to: m };
         }
       }
     }
@@ -498,8 +496,8 @@ function createGameState(mode, playerCount) {
 }
 
 function initGame(state) {
-  for (let i = 0; i < state.players.length; i++) {
-    placePieces(state.board, state.players[i]);
+  for (const player of state.players) {
+    placePieces(state.board, player);
   }
 }
 
@@ -672,8 +670,7 @@ if (typeof document !== "undefined") {
 
     // Draw valid move positions
     if (gameState.validMoves.length > 0) {
-      for (let i = 0; i < gameState.validMoves.length; i++) {
-        const moveCell = gameState.validMoves[i];
+      for (const moveCell of gameState.validMoves) {
         const pos = cellToPixel(moveCell);
         const indicator = document.createElementNS("http://www.w3.org/2000/svg", "circle");
         indicator.setAttribute("cx", pos.x);
@@ -911,9 +908,9 @@ if (typeof document !== "undefined") {
         gameState.playerTeam = firstPlayer;
         // AI gets other players
         const aiPlayers = [];
-        for (let i = 0; i < gameState.players.length; i++) {
-          if (gameState.players[i] !== firstPlayer) {
-            aiPlayers.push(gameState.players[i]);
+        for (const p of gameState.players) {
+          if (p !== firstPlayer) {
+            aiPlayers.push(p);
           }
         }
         gameState.aiTeam = aiPlayers[0]; // Primary opponent
@@ -935,8 +932,7 @@ if (typeof document !== "undefined") {
     document.getElementById("game-over").style.display = "none";
 
     let colorRulesHtml = "";
-    for (let i = 0; i < gameState.players.length; i++) {
-      const player = gameState.players[i];
+    for (const player of gameState.players) {
       const config = PLAYER_COLORS[player];
       let prefix = "";
       if (mode === "pve") {

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -117,11 +117,11 @@ function isValidPos(x, y) {
 
 function initAdjacency() {
   ADJACENT = [];
-  for (var i = 0; i < TOTAL_POSITIONS; i++) {
+  for (let i = 0; i < TOTAL_POSITIONS; i++) {
     ADJACENT[i] = [];
   }
 
-  for (var i = 0; i < TOTAL_POSITIONS; i++) {
+  for (let i = 0; i < TOTAL_POSITIONS; i++) {
     const p = positions[i];
     for (let d = 0; d < DIRECTION_VECTORS.length; d++) {
       const nx = p.x + DIRECTION_VECTORS[d].x;
@@ -146,48 +146,48 @@ const TARGET_POSITIONS = {};
 function initPlayerPositions() {
   // Player A (Red): top triangle area x=5,y=1 non-special
   START_POSITIONS[RED] = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = i; j < 4; j++) {
+  for (let i = 0; i < 4; i++) {
+    for (let j = i; j < 4; j++) {
       START_POSITIONS[RED].push(posKey[getPosKey(5 + i, 1 + j)]);
     }
   }
 
   // Player C (Blue): bottom-right triangle area x=14,y=10 non-special
   START_POSITIONS[BLUE] = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = i; j < 4; j++) {
+  for (let i = 0; i < 4; i++) {
+    for (let j = i; j < 4; j++) {
       START_POSITIONS[BLUE].push(posKey[getPosKey(14 + i, 10 + j)]);
     }
   }
 
   // Player E (Green): upper-left triangle area x=1,y=5 special
   START_POSITIONS[GREEN] = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = 0; j <= i; j++) {
+  for (let i = 0; i < 4; i++) {
+    for (let j = 0; j <= i; j++) {
       START_POSITIONS[GREEN].push(posKey[getPosKey(1 + i, 5 + j)]);
     }
   }
 
   // Player B (Yellow): right triangle area x=10,y=5 special
   START_POSITIONS[YELLOW] = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = 0; j <= i; j++) {
+  for (let i = 0; i < 4; i++) {
+    for (let j = 0; j <= i; j++) {
       START_POSITIONS[YELLOW].push(posKey[getPosKey(10 + i, 5 + j)]);
     }
   }
 
   // Player D (Purple): bottom triangle area x=10,y=14 special
   START_POSITIONS[PURPLE] = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = 0; j <= i; j++) {
+  for (let i = 0; i < 4; i++) {
+    for (let j = 0; j <= i; j++) {
       START_POSITIONS[PURPLE].push(posKey[getPosKey(10 + i, 14 + j)]);
     }
   }
 
   // Player F (Orange): left triangle area x=5,y=10 non-special
   START_POSITIONS[ORANGE] = [];
-  for (var i = 0; i < 4; i++) {
-    for (var j = i; j < 4; j++) {
+  for (let i = 0; i < 4; i++) {
+    for (let j = i; j < 4; j++) {
       START_POSITIONS[ORANGE].push(posKey[getPosKey(5 + i, 10 + j)]);
     }
   }
@@ -214,14 +214,14 @@ function initPositionScores() {
     POSITION_SCORES[player] = [];
     const targets = TARGET_POSITIONS[player];
     const targetSet = {};
-    for (var i = 0; i < targets.length; i++) {
+    for (let i = 0; i < targets.length; i++) {
       targetSet[targets[i]] = true;
     }
 
     // Calculate target area centroid
     let cx = 0,
       cy = 0;
-    for (var i = 0; i < targets.length; i++) {
+    for (let i = 0; i < targets.length; i++) {
       cx += positions[targets[i]].x;
       cy += positions[targets[i]].y;
     }
@@ -231,7 +231,7 @@ function initPositionScores() {
     // Calculate target area depth reference point (farthest vertex)
     let maxDistFromCenter = 0;
     let tipIdx = targets[0];
-    for (var i = 0; i < targets.length; i++) {
+    for (let i = 0; i < targets.length; i++) {
       const dx = positions[targets[i]].x - cx;
       const dy = positions[targets[i]].y - cy;
       const dist = Math.abs(dx) + Math.abs(dy);
@@ -607,7 +607,7 @@ if (typeof document !== "undefined") {
     // Calculate canvas size
     let maxPx = 0;
     let maxPy = 0;
-    for (var i = 0; i < TOTAL_POSITIONS; i++) {
+    for (let i = 0; i < TOTAL_POSITIONS; i++) {
       const cp = cellToPixel(i);
       if (cp.x > maxPx) maxPx = cp.x;
       if (cp.y > maxPy) maxPy = cp.y;
@@ -636,8 +636,8 @@ if (typeof document !== "undefined") {
     g.appendChild(bg);
 
     // Draw all valid positions (with area colors)
-    for (var cell = 0; cell < TOTAL_POSITIONS; cell++) {
-      var pos = cellToPixel(cell);
+    for (let cell = 0; cell < TOTAL_POSITIONS; cell++) {
+      const pos = cellToPixel(cell);
       const areaColor = getAreaColor(cell);
 
       const hex = document.createElementNS("http://www.w3.org/2000/svg", "circle");
@@ -664,7 +664,7 @@ if (typeof document !== "undefined") {
     }
 
     // Draw pieces
-    for (var cell = 0; cell < TOTAL_POSITIONS; cell++) {
+    for (let cell = 0; cell < TOTAL_POSITIONS; cell++) {
       if (gameState.board[cell] !== EMPTY) {
         drawPiece(g, cell, gameState.board[cell]);
       }
@@ -672,9 +672,9 @@ if (typeof document !== "undefined") {
 
     // Draw valid move positions
     if (gameState.validMoves.length > 0) {
-      for (var i = 0; i < gameState.validMoves.length; i++) {
+      for (let i = 0; i < gameState.validMoves.length; i++) {
         const moveCell = gameState.validMoves[i];
-        var pos = cellToPixel(moveCell);
+        const pos = cellToPixel(moveCell);
         const indicator = document.createElementNS("http://www.w3.org/2000/svg", "circle");
         indicator.setAttribute("cx", pos.x);
         indicator.setAttribute("cy", pos.y);
@@ -911,7 +911,7 @@ if (typeof document !== "undefined") {
         gameState.playerTeam = firstPlayer;
         // AI gets other players
         const aiPlayers = [];
-        for (var i = 0; i < gameState.players.length; i++) {
+        for (let i = 0; i < gameState.players.length; i++) {
           if (gameState.players[i] !== firstPlayer) {
             aiPlayers.push(gameState.players[i]);
           }
@@ -935,7 +935,7 @@ if (typeof document !== "undefined") {
     document.getElementById("game-over").style.display = "none";
 
     let colorRulesHtml = "";
-    for (var i = 0; i < gameState.players.length; i++) {
+    for (let i = 0; i < gameState.players.length; i++) {
       const player = gameState.players[i];
       const config = PLAYER_COLORS[player];
       let prefix = "";
@@ -1212,7 +1212,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -1260,7 +1260,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -943,7 +943,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver(state) {

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -239,10 +239,10 @@ function getValidMoves(board, c, r) {
 
   // General facing rule: illegal if own general faces opponent general after move
   const validMoves = [];
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     if (!isGeneralFacing(newBoard, color)) {
-      validMoves.push(moves[i]);
+      validMoves.push(move);
     }
   }
   return validMoves;
@@ -359,8 +359,7 @@ function getHorseMoves(board, c, r, color) {
     { bx: 1, by: 0, dx: 2, dy: -1 },
     { bx: 1, by: 0, dx: 2, dy: 1 },
   ];
-  for (let i = 0; i < jumps.length; i++) {
-    const j = jumps[i];
+  for (const j of jumps) {
     const bc = c + j.bx,
       br = r + j.by;
     const nc = c + j.dx,
@@ -384,8 +383,7 @@ function getElephantMoves(board, c, r, color) {
   ];
   const minR = color === RED ? 5 : 0;
   const maxR = color === RED ? 9 : 4;
-  for (let i = 0; i < jumps.length; i++) {
-    const j = jumps[i];
+  for (const j of jumps) {
     const nc = c + j.dx,
       nr = r + j.dy;
     if (!inBounds(nc, nr) || nr < minR || nr > maxR) continue;
@@ -409,9 +407,9 @@ function getAdvisorMoves(board, c, r, color) {
   ];
   const minR = color === RED ? 7 : 0;
   const maxR = color === RED ? 9 : 2;
-  for (let i = 0; i < dirs.length; i++) {
-    const nc = c + dirs[i][0],
-      nr = r + dirs[i][1];
+  for (const d of dirs) {
+    const nc = c + d[0],
+      nr = r + d[1];
     if (nc < 3 || nc > 5 || nr < minR || nr > maxR) continue;
     if (board[nc][nr] === EMPTY || getOwner(board[nc][nr]) !== color) {
       moves.push({ fromC: c, fromR: r, toC: nc, toR: nr });
@@ -430,9 +428,9 @@ function getGeneralMoves(board, c, r, color) {
   ];
   const minR = color === RED ? 7 : 0;
   const maxR = color === RED ? 9 : 2;
-  for (let i = 0; i < dirs.length; i++) {
-    const nc = c + dirs[i][0],
-      nr = r + dirs[i][1];
+  for (const d of dirs) {
+    const nc = c + d[0],
+      nr = r + d[1];
     if (nc < 3 || nc > 5 || nr < minR || nr > maxR) continue;
     if (board[nc][nr] === EMPTY || getOwner(board[nc][nr]) !== color) {
       moves.push({ fromC: c, fromR: r, toC: nc, toR: nr });
@@ -471,8 +469,8 @@ function getAllMoves(board, color) {
     for (let r = 0; r < ROWS; r++) {
       if (board[c][r] !== EMPTY && getOwner(board[c][r]) === color) {
         const pieceMoves = getValidMoves(board, c, r);
-        for (let i = 0; i < pieceMoves.length; i++) {
-          moves.push(pieceMoves[i]);
+        for (const pm of pieceMoves) {
+          moves.push(pm);
         }
       }
     }
@@ -520,8 +518,8 @@ function evaluateBoard(board, aiColor) {
       const moves = getValidMoves(board, c, r);
       const owner = getOwner(piece);
       const attackMap = owner === aiColor ? aiAttackPos : oppAttackPos;
-      for (let i = 0; i < moves.length; i++) {
-        attackMap[moves[i].toC][moves[i].toR]++;
+      for (const m of moves) {
+        attackMap[m.toC][m.toR]++;
       }
     }
   }
@@ -570,8 +568,8 @@ function alphaBeta(board, depth, alpha, beta, aiColor, isAITurn) {
   const moves = getAllMoves(board, currentPlayer);
   let bestScore = -Infinity;
 
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     const score = -alphaBeta(newBoard, depth - 1, -beta, -alpha, aiColor, !isAITurn);
     if (score > bestScore) bestScore = score;
     if (bestScore > alpha) alpha = bestScore;
@@ -587,12 +585,12 @@ function getBestAIMove(board, aiColor) {
   let bestMove = null;
   let bestScore = -Infinity;
 
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     const score = -alphaBeta(newBoard, AI_DEPTH - 1, -Infinity, Infinity, aiColor, false);
     if (score > bestScore) {
       bestScore = score;
-      bestMove = moves[i];
+      bestMove = move;
     }
   }
   return bestMove;
@@ -832,8 +830,7 @@ if (typeof document !== "undefined") {
   }
 
   function drawValidMoves(moves) {
-    for (let i = 0; i < moves.length; i++) {
-      const m = moves[i];
+    for (const m of moves) {
       const cx = toCanvasX(m.toC);
       const cy = toCanvasY(m.toR);
       if (gameState.board[m.toC][m.toR] !== EMPTY) {
@@ -1030,8 +1027,8 @@ if (typeof document !== "undefined") {
   }
 
   function findMove(moves, toC, toR) {
-    for (let i = 0; i < moves.length; i++) {
-      if (moves[i].toC === toC && moves[i].toR === toR) return moves[i];
+    for (const move of moves) {
+      if (move.toC === toC && move.toR === toR) return move;
     }
     return null;
   }

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -336,13 +336,11 @@ function getCannonMoves(board, c, r, color) {
         } else {
           jumped = true;
         }
-      } else {
-        if (board[nc][nr] !== EMPTY) {
-          if (getOwner(board[nc][nr]) !== color) {
-            moves.push({ fromC: c, fromR: r, toC: nc, toR: nr });
-          }
-          break;
+      } else if (board[nc][nr] !== EMPTY) {
+        if (getOwner(board[nc][nr]) !== color) {
+          moves.push({ fromC: c, fromR: r, toC: nc, toR: nr });
         }
+        break;
       }
     }
   }

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -1312,13 +1312,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
 
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
@@ -1451,7 +1451,7 @@ if (typeof document !== "undefined") {
       button.addEventListener("click", (ev) => {
         const player = ev.target.dataset.player;
         const choice = ev.target.dataset.choice;
-        handleRPSChoice(player, choice);
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -254,7 +254,7 @@ function isGeneralFacing(board, myColor) {
     opGC = -1,
     opGR = -1;
   for (let c = 3; c <= 5; c++) {
-    for (var r = 0; r <= 2; r++) {
+    for (let r = 0; r <= 2; r++) {
       if (board[c][r] !== EMPTY && isGeneral(board[c][r])) {
         if (getOwner(board[c][r]) === myColor) {
           myGC = c;
@@ -265,7 +265,7 @@ function isGeneralFacing(board, myColor) {
         }
       }
     }
-    for (var r = 7; r <= 9; r++) {
+    for (let r = 7; r <= 9; r++) {
       if (board[c][r] !== EMPTY && isGeneral(board[c][r])) {
         if (getOwner(board[c][r]) === myColor) {
           myGC = c;
@@ -280,7 +280,7 @@ function isGeneralFacing(board, myColor) {
   if (myGC === -1 || opGC === -1 || myGC !== opGC) return false;
   const minR = Math.min(myGR, opGR);
   const maxR = Math.max(myGR, opGR);
-  for (var r = minR + 1; r < maxR; r++) {
+  for (let r = minR + 1; r < maxR; r++) {
     if (board[myGC][r] !== EMPTY) return false;
   }
   return true;
@@ -488,10 +488,10 @@ function checkGameOver(board, nextPlayer) {
   let redGeneral = false,
     blackGeneral = false;
   for (let c = 3; c <= 5; c++) {
-    for (var r = 0; r <= 2; r++) {
+    for (let r = 0; r <= 2; r++) {
       if (board[c][r] === B_GENERAL) blackGeneral = true;
     }
-    for (var r = 7; r <= 9; r++) {
+    for (let r = 7; r <= 9; r++) {
       if (board[c][r] === R_GENERAL) redGeneral = true;
     }
   }
@@ -513,12 +513,12 @@ function evaluateBoard(board, aiColor) {
   const aiAttackPos = create2DArray(COLS, ROWS, 0);
   const oppAttackPos = create2DArray(COLS, ROWS, 0);
 
-  for (var c = 0; c < COLS; c++) {
-    for (var r = 0; r < ROWS; r++) {
-      var piece = board[c][r];
+  for (let c = 0; c < COLS; c++) {
+    for (let r = 0; r < ROWS; r++) {
+      const piece = board[c][r];
       if (piece === EMPTY) continue;
       const moves = getValidMoves(board, c, r);
-      var owner = getOwner(piece);
+      const owner = getOwner(piece);
       const attackMap = owner === aiColor ? aiAttackPos : oppAttackPos;
       for (let i = 0; i < moves.length; i++) {
         attackMap[moves[i].toC][moves[i].toR]++;
@@ -526,16 +526,16 @@ function evaluateBoard(board, aiColor) {
     }
   }
 
-  for (var c = 0; c < COLS; c++) {
-    for (var r = 0; r < ROWS; r++) {
-      var piece = board[c][r];
+  for (let c = 0; c < COLS; c++) {
+    for (let r = 0; r < ROWS; r++) {
+      const piece = board[c][r];
       if (piece === EMPTY) continue;
       let val = PIECE_VALUES[piece];
 
       if (piece === R_PAWN) val += SOLDIER_POS_RED[c][r];
       else if (piece === B_PAWN) val += SOLDIER_POS_BLACK[c][r];
 
-      var owner = getOwner(piece);
+      const owner = getOwner(piece);
       if (owner === aiColor) {
         if (oppAttackPos[c][r] > 0 && aiAttackPos[c][r] === 0) val = Math.floor(val * 0.7);
         aiScore += val;
@@ -1324,7 +1324,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -1368,7 +1368,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -512,8 +512,6 @@ function checkGameOver(board, nextPlayer) {
 function evaluateBoard(board, aiColor) {
   let aiScore = 0,
     oppScore = 0;
-  const oppColor = getOpponent(aiColor);
-
   const aiAttackPos = create2DArray(COLS, ROWS, 0);
   const oppAttackPos = create2DArray(COLS, ROWS, 0);
 

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -1237,13 +1237,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
 
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
@@ -1391,7 +1391,7 @@ if (typeof document !== "undefined") {
       button.addEventListener("click", (ev) => {
         const player = ev.target.dataset.player;
         const choice = ev.target.dataset.choice;
-        handleRPSChoice(player, choice);
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -96,12 +96,10 @@ function getLiberties(board, group) {
   const liberties = [];
   const visited = {};
 
-  for (let i = 0; i < group.length; i++) {
-    const stone = group[i];
-
-    for (let j = 0; j < DIRECTIONS.length; j++) {
-      const nx = stone.x + DIRECTIONS[j].dx;
-      const ny = stone.y + DIRECTIONS[j].dy;
+  for (const stone of group) {
+    for (const dir of DIRECTIONS) {
+      const nx = stone.x + dir.dx;
+      const ny = stone.y + dir.dy;
       const key = nx + "," + ny;
 
       if (isValidPosition(nx, ny) && !visited[key] && board[ny][nx] === EMPTY) {
@@ -122,8 +120,8 @@ function getLiberties(board, group) {
  */
 function removeGroup(board, group) {
   const newBoard = copyBoard(board);
-  for (let i = 0; i < group.length; i++) {
-    newBoard[group[i].y][group[i].x] = EMPTY;
+  for (const stone of group) {
+    newBoard[stone.y][stone.x] = EMPTY;
   }
   return newBoard;
 }
@@ -158,9 +156,9 @@ function playMove(board, x, y, player) {
   let lastCaptured = null;
 
   // Check and capture opponent groups with no liberties
-  for (let i = 0; i < DIRECTIONS.length; i++) {
-    const nx = x + DIRECTIONS[i].dx;
-    const ny = y + DIRECTIONS[i].dy;
+  for (const dir of DIRECTIONS) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
 
     if (isValidPosition(nx, ny) && newBoard[ny][nx] === opponent) {
       const group = getGroup(newBoard, nx, ny);
@@ -168,10 +166,10 @@ function playMove(board, x, y, player) {
 
       if (liberties.length === 0) {
         // Capture stones
-        for (let j = 0; j < group.stones.length; j++) {
-          newBoard[group.stones[j].y][group.stones[j].x] = EMPTY;
+        for (const stone of group.stones) {
+          newBoard[stone.y][stone.x] = EMPTY;
           totalCaptures++;
-          lastCaptured = { x: group.stones[j].x, y: group.stones[j].y };
+          lastCaptured = { x: stone.x, y: stone.y };
         }
       }
     }
@@ -281,9 +279,9 @@ function calculateScore(board) {
         const pos = queue.shift();
         territory.push(pos);
 
-        for (let i = 0; i < DIRECTIONS.length; i++) {
-          const nx = pos.x + DIRECTIONS[i].dx;
-          const ny = pos.y + DIRECTIONS[i].dy;
+        for (const dir of DIRECTIONS) {
+          const nx = pos.x + dir.dx;
+          const ny = pos.y + dir.dy;
           const nkey = nx + "," + ny;
 
           if (!isValidPosition(nx, ny) || visited[nkey]) continue;
@@ -354,9 +352,9 @@ function getBestAIMove(board, aiPlayer, koPoint, capturesBlack, capturesWhite) {
 
   // Score candidates by heuristic first, keep top N
   const scored = [];
-  for (let i = 0; i < candidateMoves.length; i++) {
-    const h = evaluateMove(board, candidateMoves[i], aiPlayer);
-    scored.push({ move: candidateMoves[i], heuristic: h });
+  for (const cm of candidateMoves) {
+    const h = evaluateMove(board, cm, aiPlayer);
+    scored.push({ move: cm, heuristic: h });
   }
   scored.sort((a, b) => b.heuristic - a.heuristic);
   const topCandidates = scored.slice(0, 12);
@@ -390,8 +388,7 @@ function filterCandidateMoves(board, legalMoves) {
   const filtered = [];
   const radius = 2;
 
-  for (let i = 0; i < legalMoves.length; i++) {
-    const move = legalMoves[i];
+  for (const move of legalMoves) {
     let nearStone = false;
 
     // Check if there are stones nearby
@@ -442,9 +439,9 @@ function evaluateMove(board, move, player) {
   const newBoard = copyBoard(board);
   newBoard[move.y][move.x] = player;
 
-  for (let i = 0; i < DIRECTIONS.length; i++) {
-    const nx = move.x + DIRECTIONS[i].dx;
-    const ny = move.y + DIRECTIONS[i].dy;
+  for (const dir of DIRECTIONS) {
+    const nx = move.x + dir.dx;
+    const ny = move.y + dir.dy;
 
     if (isValidPosition(nx, ny) && newBoard[ny][nx] === opponent) {
       const group = getGroup(newBoard, nx, ny);
@@ -698,9 +695,9 @@ if (typeof document !== "undefined") {
       { x: 15, y: 15 },
     ];
     context.fillStyle = "#8b7355";
-    for (let i = 0; i < starPoints.length; i++) {
-      const sx = MARGIN + starPoints[i].x * CELL_SIZE;
-      const sy = MARGIN + starPoints[i].y * CELL_SIZE;
+    for (const sp of starPoints) {
+      const sx = MARGIN + sp.x * CELL_SIZE;
+      const sy = MARGIN + sp.y * CELL_SIZE;
       context.beginPath();
       context.arc(sx, sy, 3, 0, Math.PI * 2);
       context.fill();

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -551,16 +551,6 @@ function getQuickMoves(board, player, koPoint, lastX, lastY) {
       if (board[y][x] !== EMPTY) continue;
       if (koPoint && koPoint.x === x && koPoint.y === y) continue;
 
-      // Quick suicide check: see if any neighbor is empty or opponent with 1 liberty
-      let hasEmptyNeighbor = false;
-      for (let d = 0; d < DIRECTIONS.length; d++) {
-        const nx = x + DIRECTIONS[d].dx;
-        const ny = y + DIRECTIONS[d].dy;
-        if (isValidPosition(nx, ny)) {
-          if (board[ny][nx] === EMPTY) hasEmptyNeighbor = true;
-        }
-      }
-
       const dist = Math.abs(x - lastX) + Math.abs(y - lastY);
       if (dist <= radius) {
         nearMoves.push({ x: x, y: y });

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -258,16 +258,16 @@ function calculateScore(board) {
   let whiteStones = 0;
 
   // Count stones
-  for (var y = 0; y < BOARD_SIZE; y++) {
-    for (var x = 0; x < BOARD_SIZE; x++) {
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    for (let x = 0; x < BOARD_SIZE; x++) {
       if (board[y][x] === BLACK) blackStones++;
       else if (board[y][x] === WHITE) whiteStones++;
     }
   }
 
   // Use flood fill to identify territory
-  for (var y = 0; y < BOARD_SIZE; y++) {
-    for (var x = 0; x < BOARD_SIZE; x++) {
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    for (let x = 0; x < BOARD_SIZE; x++) {
       const key = x + "," + y;
       if (board[y][x] !== EMPTY || visited[key]) continue;
 
@@ -354,14 +354,14 @@ function getBestAIMove(board, aiPlayer, koPoint, capturesBlack, capturesWhite) {
 
   // Score candidates by heuristic first, keep top N
   const scored = [];
-  for (var i = 0; i < candidateMoves.length; i++) {
+  for (let i = 0; i < candidateMoves.length; i++) {
     const h = evaluateMove(board, candidateMoves[i], aiPlayer);
     scored.push({ move: candidateMoves[i], heuristic: h });
   }
   scored.sort((a, b) => b.heuristic - a.heuristic);
   const topCandidates = scored.slice(0, 12);
 
-  for (var i = 0; i < topCandidates.length; i++) {
+  for (let i = 0; i < topCandidates.length; i++) {
     const move = topCandidates[i].move;
     let wins = 0;
 
@@ -671,7 +671,7 @@ if (typeof document !== "undefined") {
     // Grid lines
     context.strokeStyle = "#8b7355";
     context.lineWidth = 1;
-    for (var i = 0; i < BOARD_SIZE; i++) {
+    for (let i = 0; i < BOARD_SIZE; i++) {
       const pos = MARGIN + i * CELL_SIZE;
       // Vertical lines
       context.beginPath();
@@ -698,7 +698,7 @@ if (typeof document !== "undefined") {
       { x: 15, y: 15 },
     ];
     context.fillStyle = "#8b7355";
-    for (var i = 0; i < starPoints.length; i++) {
+    for (let i = 0; i < starPoints.length; i++) {
       const sx = MARGIN + starPoints[i].x * CELL_SIZE;
       const sy = MARGIN + starPoints[i].y * CELL_SIZE;
       context.beginPath();
@@ -1249,7 +1249,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -1293,7 +1293,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -359,8 +359,8 @@ function getBestAIMove(board, aiPlayer, koPoint, capturesBlack, capturesWhite) {
   scored.sort((a, b) => b.heuristic - a.heuristic);
   const topCandidates = scored.slice(0, 12);
 
-  for (let i = 0; i < topCandidates.length; i++) {
-    const move = topCandidates[i].move;
+  for (const candidate of topCandidates) {
+    const move = candidate.move;
     let wins = 0;
 
     for (let s = 0; s < simulations; s++) {
@@ -369,7 +369,7 @@ function getBestAIMove(board, aiPlayer, koPoint, capturesBlack, capturesWhite) {
     }
 
     const winRate = wins / simulations;
-    const score = winRate * 100 + topCandidates[i].heuristic;
+    const score = winRate * 100 + candidate.heuristic;
 
     if (score > bestScore) {
       bestScore = score;

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -816,7 +816,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver(state) {

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -345,7 +345,6 @@ function getBestAIMove(board, aiPlayer, koPoint, capturesBlack, capturesWhite) {
     return legalMoves[0];
   }
 
-  const humanPlayer = getOpponent(aiPlayer);
   const simulations = 20; // Reduced for performance on 19x19 board
   let bestMove = null;
   let bestScore = -Infinity;
@@ -544,7 +543,6 @@ function simulateGame(board, firstMove, aiPlayer, koPoint, capturesBlack, captur
  */
 function getQuickMoves(board, player, koPoint, lastX, lastY) {
   const moves = [];
-  const captureMoves = [];
   const nearMoves = [];
   const radius = 1;
 
@@ -555,7 +553,6 @@ function getQuickMoves(board, player, koPoint, lastX, lastY) {
 
       // Quick suicide check: see if any neighbor is empty or opponent with 1 liberty
       let hasEmptyNeighbor = false;
-      const canCapture = false;
       for (let d = 0; d < DIRECTIONS.length; d++) {
         const nx = x + DIRECTIONS[d].dx;
         const ny = y + DIRECTIONS[d].dy;

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -120,12 +120,11 @@ function getPlayerName(player) {
  */
 function checkWinAt(board, x, y, player) {
   const lines = WINS_MAP[x][y];
-  for (let i = 0; i < lines.length; i++) {
-    const lineId = lines[i];
+  for (const lineId of lines) {
     const line = WIN_LINES[lineId];
     let count = 0;
-    for (let k = 0; k < line.length; k++) {
-      if (board[line[k].y][line[k].x] === player) {
+    for (const pos of line) {
+      if (board[pos.y][pos.x] === player) {
         count++;
       }
     }
@@ -347,9 +346,9 @@ if (typeof document !== "undefined") {
       { x: 11, y: 11 },
     ];
     context.fillStyle = "#8b7355";
-    for (let i = 0; i < starPoints.length; i++) {
-      const sx = MARGIN + starPoints[i].x * CELL_SIZE;
-      const sy = MARGIN + starPoints[i].y * CELL_SIZE;
+    for (const sp of starPoints) {
+      const sx = MARGIN + sp.x * CELL_SIZE;
+      const sy = MARGIN + sp.y * CELL_SIZE;
       context.beginPath();
       context.arc(sx, sy, 3, 0, Math.PI * 2);
       context.fill();

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -465,7 +465,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver(state) {

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -31,11 +31,11 @@ function initWinLines() {
   let lineId = 0;
 
   // Horizontal
-  for (var y = 0; y < BOARD_SIZE; y++) {
-    for (var x = 0; x <= BOARD_SIZE - WIN_COUNT; x++) {
-      var line = [];
-      for (var k = 0; k < WIN_COUNT; k++) {
-        var pos = { x: x + k, y: y };
+  for (let y = 0; y < BOARD_SIZE; y++) {
+    for (let x = 0; x <= BOARD_SIZE - WIN_COUNT; x++) {
+      const line = [];
+      for (let k = 0; k < WIN_COUNT; k++) {
+        const pos = { x: x + k, y: y };
         line.push(pos);
         WINS_MAP[pos.x][pos.y].push(lineId);
       }
@@ -45,11 +45,11 @@ function initWinLines() {
   }
 
   // Vertical
-  for (var x = 0; x < BOARD_SIZE; x++) {
-    for (var y = 0; y <= BOARD_SIZE - WIN_COUNT; y++) {
-      var line = [];
-      for (var k = 0; k < WIN_COUNT; k++) {
-        var pos = { x: x, y: y + k };
+  for (let x = 0; x < BOARD_SIZE; x++) {
+    for (let y = 0; y <= BOARD_SIZE - WIN_COUNT; y++) {
+      const line = [];
+      for (let k = 0; k < WIN_COUNT; k++) {
+        const pos = { x: x, y: y + k };
         line.push(pos);
         WINS_MAP[pos.x][pos.y].push(lineId);
       }
@@ -59,11 +59,11 @@ function initWinLines() {
   }
 
   // Down-right diagonal (\) (\)
-  for (var x = 0; x <= BOARD_SIZE - WIN_COUNT; x++) {
-    for (var y = 0; y <= BOARD_SIZE - WIN_COUNT; y++) {
-      var line = [];
-      for (var k = 0; k < WIN_COUNT; k++) {
-        var pos = { x: x + k, y: y + k };
+  for (let x = 0; x <= BOARD_SIZE - WIN_COUNT; x++) {
+    for (let y = 0; y <= BOARD_SIZE - WIN_COUNT; y++) {
+      const line = [];
+      for (let k = 0; k < WIN_COUNT; k++) {
+        const pos = { x: x + k, y: y + k };
         line.push(pos);
         WINS_MAP[pos.x][pos.y].push(lineId);
       }
@@ -73,11 +73,11 @@ function initWinLines() {
   }
 
   // Down-left diagonal (/) (/)
-  for (var x = WIN_COUNT - 1; x < BOARD_SIZE; x++) {
-    for (var y = 0; y <= BOARD_SIZE - WIN_COUNT; y++) {
-      var line = [];
-      for (var k = 0; k < WIN_COUNT; k++) {
-        var pos = { x: x - k, y: y + k };
+  for (let x = WIN_COUNT - 1; x < BOARD_SIZE; x++) {
+    for (let y = 0; y <= BOARD_SIZE - WIN_COUNT; y++) {
+      const line = [];
+      for (let k = 0; k < WIN_COUNT; k++) {
+        const pos = { x: x - k, y: y + k };
         line.push(pos);
         WINS_MAP[pos.x][pos.y].push(lineId);
       }
@@ -179,7 +179,7 @@ function getBestAIMove(board, aiPlayer) {
     const line = WIN_LINES[lid];
     let aiCount = 0;
     let humanCount = 0;
-    for (var k = 0; k < line.length; k++) {
+    for (let k = 0; k < line.length; k++) {
       const val = board[line[k].y][line[k].x];
       if (val === aiPlayer) aiCount++;
       else if (val === humanPlayer) humanCount++;
@@ -190,14 +190,14 @@ function getBestAIMove(board, aiPlayer) {
 
     if (aiCount > 0 && humanCount === 0) {
       // AI's line, add score to empty positions
-      for (var k = 0; k < line.length; k++) {
+      for (let k = 0; k < line.length; k++) {
         if (board[line[k].y][line[k].x] === EMPTY) {
           scoreAI[line[k].x][line[k].y] += SCORE_AI[aiCount];
         }
       }
     } else if (humanCount > 0 && aiCount === 0) {
       // Human's line, add score to empty positions (defense score)
-      for (var k = 0; k < line.length; k++) {
+      for (let k = 0; k < line.length; k++) {
         if (board[line[k].y][line[k].x] === EMPTY) {
           scoreHuman[line[k].x][line[k].y] += SCORE_HUMAN[humanCount];
         }
@@ -324,7 +324,7 @@ if (typeof document !== "undefined") {
     // Grid lines
     context.strokeStyle = "#8b7355";
     context.lineWidth = 1;
-    for (var i = 0; i < BOARD_SIZE; i++) {
+    for (let i = 0; i < BOARD_SIZE; i++) {
       const pos = MARGIN + i * CELL_SIZE;
       // Vertical lines
       context.beginPath();
@@ -347,7 +347,7 @@ if (typeof document !== "undefined") {
       { x: 11, y: 11 },
     ];
     context.fillStyle = "#8b7355";
-    for (var i = 0; i < starPoints.length; i++) {
+    for (let i = 0; i < starPoints.length; i++) {
       const sx = MARGIN + starPoints[i].x * CELL_SIZE;
       const sy = MARGIN + starPoints[i].y * CELL_SIZE;
       context.beginPath();
@@ -801,7 +801,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -845,7 +845,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -189,16 +189,16 @@ function getBestAIMove(board, aiPlayer) {
 
     if (aiCount > 0 && humanCount === 0) {
       // AI's line, add score to empty positions
-      for (let k = 0; k < line.length; k++) {
-        if (board[line[k].y][line[k].x] === EMPTY) {
-          scoreAI[line[k].x][line[k].y] += SCORE_AI[aiCount];
+      for (const point of line) {
+        if (board[point.y][point.x] === EMPTY) {
+          scoreAI[point.x][point.y] += SCORE_AI[aiCount];
         }
       }
     } else if (humanCount > 0 && aiCount === 0) {
       // Human's line, add score to empty positions (defense score)
-      for (let k = 0; k < line.length; k++) {
-        if (board[line[k].y][line[k].x] === EMPTY) {
-          scoreHuman[line[k].x][line[k].y] += SCORE_HUMAN[humanCount];
+      for (const point of line) {
+        if (board[point.y][point.x] === EMPTY) {
+          scoreHuman[point.x][point.y] += SCORE_HUMAN[humanCount];
         }
       }
     }

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -789,13 +789,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
 
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
@@ -943,7 +943,7 @@ if (typeof document !== "undefined") {
       button.addEventListener("click", (ev) => {
         const player = ev.target.dataset.player;
         const choice = ev.target.dataset.choice;
-        handleRPSChoice(player, choice);
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -643,7 +643,6 @@ function getPositionValue(piece, c, r) {
 function evaluateBoard(board, aiColor) {
   let aiScore = 0,
     oppScore = 0;
-  const oppColor = getOpponent(aiColor);
   for (let c = 0; c < BOARD_SIZE; c++) {
     for (let r = 0; r < BOARD_SIZE; r++) {
       const piece = board[c][r];
@@ -1143,7 +1142,6 @@ if (typeof document !== "undefined") {
   }
 
   function doMove(move) {
-    const piece = gameState.board[move.fromC][move.fromR];
     gameState.hasMoved.add(move.fromC + "," + move.fromR);
     gameState.hasMoved.add(move.toC + "," + move.toR);
     if (move.castling) {

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -690,18 +690,18 @@ function getBestAIMove(board, aiColor, hasMoved) {
     let scoreA;
     if (a.promotion) {
       scoreA = 800;
-    } else if (board[a.toC][a.toR] !== EMPTY) {
-      scoreA = PIECE_VALUES[board[a.toC][a.toR]];
-    } else {
+    } else if (board[a.toC][a.toR] === EMPTY) {
       scoreA = 0;
+    } else {
+      scoreA = PIECE_VALUES[board[a.toC][a.toR]];
     }
     let scoreB;
     if (b.promotion) {
       scoreB = 800;
-    } else if (board[b.toC][b.toR] !== EMPTY) {
-      scoreB = PIECE_VALUES[board[b.toC][b.toR]];
-    } else {
+    } else if (board[b.toC][b.toR] === EMPTY) {
       scoreB = 0;
+    } else {
+      scoreB = PIECE_VALUES[board[b.toC][b.toR]];
     }
     return scoreB - scoreA;
   });

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -248,10 +248,10 @@ function getValidMoves(board, c, r, hasMoved) {
 
   // Filter moves that leave own king in check
   const validMoves = [];
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     if (!isInCheck(newBoard, color)) {
-      validMoves.push(moves[i]);
+      validMoves.push(move);
     }
   }
   return validMoves;
@@ -282,8 +282,8 @@ function isSquareAttacked(board, tc, tr, byColor) {
       const piece = board[c][r];
       if (piece === EMPTY || getOwner(piece) !== byColor) continue;
       const attacks = getRawAttacks(board, c, r, piece);
-      for (let i = 0; i < attacks.length; i++) {
-        if (attacks[i].toC === tc && attacks[i].toR === tr) return true;
+      for (const a of attacks) {
+        if (a.toC === tc && a.toR === tr) return true;
       }
     }
   }
@@ -369,9 +369,9 @@ function getKnightAttacks(board, c, r, color) {
     [2, -1],
     [2, 1],
   ];
-  for (let i = 0; i < jumps.length; i++) {
-    const nc = c + jumps[i][0],
-      nr = r + jumps[i][1];
+  for (const j of jumps) {
+    const nc = c + j[0],
+      nr = r + j[1];
     if (inBounds(nc, nr)) moves.push({ toC: nc, toR: nr });
   }
   return moves;
@@ -389,9 +389,9 @@ function getKingAttacks(board, c, r, color) {
     [1, 0],
     [1, 1],
   ];
-  for (let i = 0; i < dirs.length; i++) {
-    const nc = c + dirs[i][0],
-      nr = r + dirs[i][1];
+  for (const d of dirs) {
+    const nc = c + d[0],
+      nr = r + d[1];
     if (inBounds(nc, nr)) moves.push({ toC: nc, toR: nr });
   }
   return moves;
@@ -493,9 +493,9 @@ function getKingMoves(board, c, r, color, hasMoved) {
     [1, 0],
     [1, 1],
   ];
-  for (let i = 0; i < dirs.length; i++) {
-    const nc = c + dirs[i][0],
-      nr = r + dirs[i][1];
+  for (const d of dirs) {
+    const nc = c + d[0],
+      nr = r + d[1];
     if (inBounds(nc, nr) && (board[nc][nr] === EMPTY || getOwner(board[nc][nr]) !== color)) {
       moves.push({ fromC: c, fromR: r, toC: nc, toR: nr });
     }
@@ -596,7 +596,7 @@ function getAllMoves(board, color, hasMoved) {
     for (let r = 0; r < BOARD_SIZE; r++) {
       if (board[c][r] !== EMPTY && getOwner(board[c][r]) === color) {
         const pieceMoves = getValidMoves(board, c, r, hasMoved);
-        for (let i = 0; i < pieceMoves.length; i++) moves.push(pieceMoves[i]);
+        for (const pm of pieceMoves) moves.push(pm);
       }
     }
   }
@@ -668,8 +668,8 @@ function alphaBeta(board, depth, alpha, beta, aiColor, isAITurn, hasMoved) {
   const moves = getAllMoves(board, currentPlayer, hasMoved);
   let bestScore = -Infinity;
 
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     const score = -alphaBeta(newBoard, depth - 1, -beta, -alpha, aiColor, !isAITurn, hasMoved);
     if (score > bestScore) bestScore = score;
     if (bestScore > alpha) alpha = bestScore;
@@ -706,12 +706,12 @@ function getBestAIMove(board, aiColor, hasMoved) {
     return scoreB - scoreA;
   });
 
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = applyMove(board, moves[i]);
+  for (const move of moves) {
+    const newBoard = applyMove(board, move);
     const score = -alphaBeta(newBoard, AI_DEPTH - 1, -Infinity, Infinity, aiColor, false, hasMoved);
     if (score > bestScore) {
       bestScore = score;
-      bestMove = moves[i];
+      bestMove = move;
     }
   }
   return bestMove;
@@ -908,8 +908,7 @@ if (typeof document !== "undefined") {
   }
 
   function drawValidMoves(moves) {
-    for (let i = 0; i < moves.length; i++) {
-      const m = moves[i];
+    for (const m of moves) {
       const cx = toCanvasX(m.toC) + CELL_SIZE / 2;
       const cy = toCanvasY(m.toR) + CELL_SIZE / 2;
       if (gameState.board[m.toC][m.toR] !== EMPTY) {
@@ -1143,12 +1142,12 @@ if (typeof document !== "undefined") {
 
   function findMove(moves, toC, toR) {
     // Prefer non-promotion moves, promotion moves need dialog
-    for (let i = 0; i < moves.length; i++) {
-      if (moves[i].toC === toC && moves[i].toR === toR && !moves[i].promotion) return moves[i];
+    for (const move of moves) {
+      if (move.toC === toC && move.toR === toR && !move.promotion) return move;
     }
     // If only promotion moves, return first (triggers promotion dialog)
-    for (let i = 0; i < moves.length; i++) {
-      if (moves[i].toC === toC && moves[i].toR === toR) return moves[i];
+    for (const move of moves) {
+      if (move.toC === toC && move.toR === toR) return move;
     }
     return null;
   }

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -687,16 +687,22 @@ function getBestAIMove(board, aiColor, hasMoved) {
 
   // Prioritize captures and promotions
   moves.sort((a, b) => {
-    const scoreA = a.promotion
-      ? 800
-      : board[a.toC][a.toR] !== EMPTY
-        ? PIECE_VALUES[board[a.toC][a.toR]]
-        : 0;
-    const scoreB = b.promotion
-      ? 800
-      : board[b.toC][b.toR] !== EMPTY
-        ? PIECE_VALUES[board[b.toC][b.toR]]
-        : 0;
+    let scoreA;
+    if (a.promotion) {
+      scoreA = 800;
+    } else if (board[a.toC][a.toR] !== EMPTY) {
+      scoreA = PIECE_VALUES[board[a.toC][a.toR]];
+    } else {
+      scoreA = 0;
+    }
+    let scoreB;
+    if (b.promotion) {
+      scoreB = 800;
+    } else if (board[b.toC][b.toR] !== EMPTY) {
+      scoreB = PIECE_VALUES[board[b.toC][b.toR]];
+    } else {
+      scoreB = 0;
+    }
     return scoreB - scoreA;
   });
 
@@ -1009,7 +1015,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver(state) {

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -166,7 +166,7 @@ function isKing(piece) {
 
 function createBoard() {
   const board = [];
-  for (var c = 0; c < BOARD_SIZE; c++) {
+  for (let c = 0; c < BOARD_SIZE; c++) {
     const col = [];
     for (let r = 0; r < BOARD_SIZE; r++) col.push(EMPTY);
     board.push(col);
@@ -180,7 +180,7 @@ function createBoard() {
   board[5][0] = B_BISHOP;
   board[6][0] = B_KNIGHT;
   board[7][0] = B_ROOK;
-  for (var c = 0; c < 8; c++) board[c][1] = B_PAWN;
+  for (let c = 0; c < 8; c++) board[c][1] = B_PAWN;
   // White (bottom, row 6-7)
   board[0][7] = W_ROOK;
   board[1][7] = W_KNIGHT;
@@ -190,7 +190,7 @@ function createBoard() {
   board[5][7] = W_BISHOP;
   board[6][7] = W_KNIGHT;
   board[7][7] = W_ROOK;
-  for (var c = 0; c < 8; c++) board[c][6] = W_PAWN;
+  for (let c = 0; c < 8; c++) board[c][6] = W_PAWN;
   return board;
 }
 
@@ -553,11 +553,11 @@ function getPawnMoves(board, c, r, color, hasMoved) {
   // Move forward one step
   if (inBounds(c, r + dir) && board[c][r + dir] === EMPTY) {
     if (r + dir === promoRow) {
-      var promos =
+      const promos =
         color === WHITE
           ? [W_QUEEN, W_ROOK, W_BISHOP, W_KNIGHT]
           : [B_QUEEN, B_ROOK, B_BISHOP, B_KNIGHT];
-      for (var p = 0; p < promos.length; p++) {
+      for (let p = 0; p < promos.length; p++) {
         moves.push({ fromC: c, fromR: r, toC: c, toR: r + dir, promotion: promos[p] });
       }
     } else {
@@ -575,11 +575,11 @@ function getPawnMoves(board, c, r, color, hasMoved) {
       nr = r + dir;
     if (inBounds(nc, nr) && board[nc][nr] !== EMPTY && getOwner(board[nc][nr]) !== color) {
       if (nr === promoRow) {
-        var promos =
+        const promos =
           color === WHITE
             ? [W_QUEEN, W_ROOK, W_BISHOP, W_KNIGHT]
             : [B_QUEEN, B_ROOK, B_BISHOP, B_KNIGHT];
-        for (var p = 0; p < promos.length; p++) {
+        for (let p = 0; p < promos.length; p++) {
           moves.push({ fromC: c, fromR: r, toC: nc, toR: nr, promotion: promos[p] });
         }
       } else {
@@ -839,8 +839,8 @@ if (typeof document !== "undefined") {
   function drawBoard() {
     const lightColor = "#f0d9b5";
     const darkColor = "#b58863";
-    for (var r = 0; r < BOARD_SIZE; r++) {
-      for (var c = 0; c < BOARD_SIZE; c++) {
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      for (let c = 0; c < BOARD_SIZE; c++) {
         context.fillStyle = (c + r) % 2 === 0 ? lightColor : darkColor;
         context.fillRect(toCanvasX(c), toCanvasY(r), CELL_SIZE, CELL_SIZE);
       }
@@ -852,11 +852,11 @@ if (typeof document !== "undefined") {
     context.textBaseline = "middle";
     const files = "abcdefgh";
     const flipped = gameState && gameState.boardFlipped;
-    for (var c = 0; c < BOARD_SIZE; c++) {
+    for (let c = 0; c < BOARD_SIZE; c++) {
       const fileIdx = flipped ? 7 - c : c;
       context.fillText(files[fileIdx], PADDING + c * CELL_SIZE + CELL_SIZE / 2, CANVAS_SIZE - 8);
     }
-    for (var r = 0; r < BOARD_SIZE; r++) {
+    for (let r = 0; r < BOARD_SIZE; r++) {
       const rankNum = flipped ? r + 1 : 8 - r;
       context.fillText(String(rankNum), 10, PADDING + r * CELL_SIZE + CELL_SIZE / 2);
     }
@@ -1143,11 +1143,11 @@ if (typeof document !== "undefined") {
 
   function findMove(moves, toC, toR) {
     // Prefer non-promotion moves, promotion moves need dialog
-    for (var i = 0; i < moves.length; i++) {
+    for (let i = 0; i < moves.length; i++) {
       if (moves[i].toC === toC && moves[i].toR === toR && !moves[i].promotion) return moves[i];
     }
     // If only promotion moves, return first (triggers promotion dialog)
-    for (var i = 0; i < moves.length; i++) {
+    for (let i = 0; i < moves.length; i++) {
       if (moves[i].toC === toC && moves[i].toR === toR) return moves[i];
     }
     return null;
@@ -1440,7 +1440,7 @@ if (typeof document !== "undefined") {
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
       if (humanWins === 1) {
         resultEl.textContent =
@@ -1481,7 +1481,7 @@ if (typeof document !== "undefined") {
       document.getElementById("rps-p" + player + "-status").textContent =
         "已选择：" + getRPSName(choice);
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
         if (winner === 1) {
           resultEl.textContent = "玩家1赢了！玩家1先手(白方)。";

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -504,7 +504,7 @@ function getKingMoves(board, c, r, color, hasMoved) {
   if (hasMoved && !hasMoved.has(c + "," + r)) {
     const row = r;
     // King-side castling (king-side)
-    const kRookMoved = hasMoved && hasMoved.has("7," + row);
+    const kRookMoved = hasMoved.has("7," + row);
     const kPathClear = board[5][row] === EMPTY && board[6][row] === EMPTY;
     if (
       !kRookMoved &&
@@ -522,7 +522,7 @@ function getKingMoves(board, c, r, color, hasMoved) {
       }
     }
     // Queen-side castling (queen-side)
-    const qRookMoved = hasMoved && hasMoved.has("0," + row);
+    const qRookMoved = hasMoved.has("0," + row);
     const qPathClear =
       board[1][row] === EMPTY && board[2][row] === EMPTY && board[3][row] === EMPTY;
     if (

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -1430,13 +1430,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
@@ -1559,7 +1559,7 @@ if (typeof document !== "undefined") {
 
     document.querySelectorAll(".btn-rps").forEach((button) => {
       button.addEventListener("click", (ev) => {
-        handleRPSChoice(ev.target.dataset.player, ev.target.dataset.choice);
+        handleRPSChoice(ev.target.dataset.player, ev.target.dataset.choice, ev);
       });
     });
     document.getElementById("btn-restart").addEventListener("click", restartGame);

--- a/apps/board-game/reversi/game.js
+++ b/apps/board-game/reversi/game.js
@@ -110,7 +110,6 @@ function isValidMove(board, x, y, player) {
   // Position must be empty
   if (board[y][x] !== null) return null;
 
-  const opponent = getOpponent(player);
   const allFlipped = [];
 
   // Check all directions
@@ -304,7 +303,7 @@ function aiTurn(state) {
 
     if (bestMove) {
       // AI has valid move position
-      const flipped = makeMove(state.board, bestMove.x, bestMove.y, state.aiTeam);
+      makeMove(state.board, bestMove.x, bestMove.y, state.aiTeam);
       state.lastMove = { x: bestMove.x, y: bestMove.y };
       state.turnCount++;
 
@@ -561,7 +560,7 @@ function handleCellClick(x, y) {
   }
 
   // Execute move
-  const flipped = makeMove(gameState.board, x, y, gameState.currentPlayer);
+  makeMove(gameState.board, x, y, gameState.currentPlayer);
   gameState.lastMove = { x, y };
   gameState.turnCount++;
 

--- a/apps/board-game/reversi/game.js
+++ b/apps/board-game/reversi/game.js
@@ -857,13 +857,13 @@ let rpsChoices = { player1: null, player2: null, human: null };
  * @param {string} player - '1' | '2' | 'human'
  * @param {string} choice - 'rock' | 'scissors' | 'paper'
  */
-function handleRPSChoice(player, choice) {
+function handleRPSChoice(player, choice, ev) {
   if (player === "human") {
     rpsChoices.human = choice;
     document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
       btn.classList.remove("selected");
     });
-    event.target.classList.add("selected");
+    ev.target.classList.add("selected");
 
     // AI random choice
     const choices = ["rock", "scissors", "paper"];
@@ -1001,10 +1001,10 @@ if (typeof document !== "undefined") {
 
     // RPS buttons
     document.querySelectorAll(".btn-rps").forEach((button) => {
-      button.addEventListener("click", (event) => {
-        const player = event.target.dataset.player;
-        const choice = event.target.dataset.choice;
-        handleRPSChoice(player, choice);
+      button.addEventListener("click", (ev) => {
+        const player = ev.target.dataset.player;
+        const choice = ev.target.dataset.choice;
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -81,8 +81,7 @@ function createGameState(mode) {
 }
 
 function checkWin(board) {
-  for (let i = 0; i < WIN_LINES.length; i++) {
-    const line = WIN_LINES[i];
+  for (const line of WIN_LINES) {
     const a = board[line[0].y][line[0].x];
     const b = board[line[1].y][line[1].x];
     const c = board[line[2].y][line[2].x];
@@ -141,8 +140,8 @@ function minimax(board, depth, isMaximizing, aiPlayer) {
   const moves = getValidMoves(board);
   if (isMaximizing) {
     let best = -100;
-    for (let i = 0; i < moves.length; i++) {
-      const newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
+    for (const move of moves) {
+      const newBoard = makeMove(board, move.x, move.y, aiPlayer);
       const score = minimax(newBoard, depth + 1, false, aiPlayer);
       if (score > best) best = score;
     }
@@ -150,8 +149,8 @@ function minimax(board, depth, isMaximizing, aiPlayer) {
   } else {
     let best = 100;
     const opponent = getOpponent(aiPlayer);
-    for (let i = 0; i < moves.length; i++) {
-      const newBoard = makeMove(board, moves[i].x, moves[i].y, opponent);
+    for (const move of moves) {
+      const newBoard = makeMove(board, move.x, move.y, opponent);
       const score = minimax(newBoard, depth + 1, true, aiPlayer);
       if (score < best) best = score;
     }
@@ -164,27 +163,27 @@ function getBestAIMove(board, aiPlayer) {
   if (moves.length === 0) return null;
 
   // First check if AI can win immediately
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
-    if (checkWin(newBoard)) return moves[i];
+  for (const move of moves) {
+    const newBoard = makeMove(board, move.x, move.y, aiPlayer);
+    if (checkWin(newBoard)) return move;
   }
 
   // Then check if opponent can win immediately (need to block)
   const opponent = getOpponent(aiPlayer);
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = makeMove(board, moves[i].x, moves[i].y, opponent);
-    if (checkWin(newBoard)) return moves[i];
+  for (const move of moves) {
+    const newBoard = makeMove(board, move.x, move.y, opponent);
+    if (checkWin(newBoard)) return move;
   }
 
   // Minimax selects optimal move
   let bestScore = -100;
   let bestMove = moves[0];
-  for (let i = 0; i < moves.length; i++) {
-    const newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
+  for (const move of moves) {
+    const newBoard = makeMove(board, move.x, move.y, aiPlayer);
     const score = minimax(newBoard, 0, false, aiPlayer);
     if (score > bestScore) {
       bestScore = score;
-      bestMove = moves[i];
+      bestMove = move;
     }
   }
   return bestMove;
@@ -290,8 +289,7 @@ if (typeof document !== "undefined") {
 
     // Highlight winning line
     if (state.winLine) {
-      for (let i = 0; i < state.winLine.length; i++) {
-        const pos = state.winLine[i];
+      for (const pos of state.winLine) {
         const sel = '.cell[data-x="' + pos.x + '"][data-y="' + pos.y + '"]';
         const winCell = document.querySelector(sel);
         if (winCell) winCell.classList.add("cell-win");

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -140,19 +140,19 @@ function minimax(board, depth, isMaximizing, aiPlayer) {
 
   const moves = getValidMoves(board);
   if (isMaximizing) {
-    var best = -100;
-    for (var i = 0; i < moves.length; i++) {
-      var newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
-      var score = minimax(newBoard, depth + 1, false, aiPlayer);
+    let best = -100;
+    for (let i = 0; i < moves.length; i++) {
+      const newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
+      const score = minimax(newBoard, depth + 1, false, aiPlayer);
       if (score > best) best = score;
     }
     return best;
   } else {
-    var best = 100;
+    let best = 100;
     const opponent = getOpponent(aiPlayer);
-    for (var i = 0; i < moves.length; i++) {
-      var newBoard = makeMove(board, moves[i].x, moves[i].y, opponent);
-      var score = minimax(newBoard, depth + 1, true, aiPlayer);
+    for (let i = 0; i < moves.length; i++) {
+      const newBoard = makeMove(board, moves[i].x, moves[i].y, opponent);
+      const score = minimax(newBoard, depth + 1, true, aiPlayer);
       if (score < best) best = score;
     }
     return best;
@@ -164,23 +164,23 @@ function getBestAIMove(board, aiPlayer) {
   if (moves.length === 0) return null;
 
   // First check if AI can win immediately
-  for (var i = 0; i < moves.length; i++) {
-    var newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
+  for (let i = 0; i < moves.length; i++) {
+    const newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
     if (checkWin(newBoard)) return moves[i];
   }
 
   // Then check if opponent can win immediately (need to block)
   const opponent = getOpponent(aiPlayer);
-  for (var i = 0; i < moves.length; i++) {
-    var newBoard = makeMove(board, moves[i].x, moves[i].y, opponent);
+  for (let i = 0; i < moves.length; i++) {
+    const newBoard = makeMove(board, moves[i].x, moves[i].y, opponent);
     if (checkWin(newBoard)) return moves[i];
   }
 
   // Minimax selects optimal move
   let bestScore = -100;
   let bestMove = moves[0];
-  for (var i = 0; i < moves.length; i++) {
-    var newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
+  for (let i = 0; i < moves.length; i++) {
+    const newBoard = makeMove(board, moves[i].x, moves[i].y, aiPlayer);
     const score = minimax(newBoard, 0, false, aiPlayer);
     if (score > bestScore) {
       bestScore = score;
@@ -639,7 +639,7 @@ if (typeof document !== "undefined") {
       const aiChoice = choices[Math.floor(Math.random() * 3)];
       rpsChoices.player2 = aiChoice;
 
-      var resultEl = document.getElementById("rps-result");
+      const resultEl = document.getElementById("rps-result");
       const humanWins = judgeRPS(choice, aiChoice);
 
       if (humanWins === 1) {
@@ -683,7 +683,7 @@ if (typeof document !== "undefined") {
       statusEl.textContent = "已选择：" + getRPSName(choice);
 
       if (rpsChoices.player1 && rpsChoices.player2) {
-        var resultEl = document.getElementById("rps-result");
+        const resultEl = document.getElementById("rps-result");
         const winner = judgeRPS(rpsChoices.player1, rpsChoices.player2);
 
         if (winner === 1) {

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -312,7 +312,13 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    el.className = type === "error" ? "error" : type === "info" ? "info" : "";
+    if (type === "error") {
+      el.className = "error";
+    } else if (type === "info") {
+      el.className = "info";
+    } else {
+      el.className = "";
+    }
   }
 
   function showGameOver(state) {

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -627,13 +627,13 @@ if (typeof document !== "undefined") {
     cleanupNetwork();
   }
 
-  function handleRPSChoice(player, choice) {
+  function handleRPSChoice(player, choice, ev) {
     if (player === "human") {
       rpsChoices.human = choice;
       document.querySelectorAll("#rps-player-buttons .btn-rps").forEach((btn) => {
         btn.classList.remove("selected");
       });
-      event.target.classList.add("selected");
+      ev.target.classList.add("selected");
 
       const choices = ["rock", "scissors", "paper"];
       const aiChoice = choices[Math.floor(Math.random() * 3)];
@@ -781,7 +781,7 @@ if (typeof document !== "undefined") {
       button.addEventListener("click", (ev) => {
         const player = ev.target.dataset.player;
         const choice = ev.target.dataset.choice;
-        handleRPSChoice(player, choice);
+        handleRPSChoice(player, choice, ev);
       });
     });
 

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -839,7 +839,6 @@ if (typeof document !== "undefined") {
     // Click opponent face-up card (no selection)
     if (card && card.faceUp && card.team !== currentTeam) {
       showMessage("这不是你的棋子", "error");
-      return;
     }
   });
 

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -1053,8 +1053,12 @@ if (typeof document !== "undefined") {
         }
         handleOnlineRPSResult({ result: "draw" });
       } else {
-        const winnerRole =
-          result === 1 ? localPlayerRole : localPlayerRole === "host" ? "guest" : "host";
+        let winnerRole;
+        if (result === 1) {
+          winnerRole = localPlayerRole;
+        } else {
+          winnerRole = localPlayerRole === "host" ? "guest" : "host";
+        }
         const rpsResult = { result: "win", winner: winnerRole };
         if (networkProtocol) {
           networkProtocol.sendRPSResult(rpsResult);

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -1068,7 +1068,6 @@ if (typeof document !== "undefined") {
   }
 
   function handleOnlineRPSResult(rpsResult) {
-    const choiceNames = { rock: "石头", scissors: "剪刀", paper: "布" };
     const $rpsOnlineResult = document.getElementById("rps-online-result");
 
     if (rpsResult.result === "draw") {

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -952,16 +952,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage(gameState.currentTeam === localTeam ? "你的回合" : "等待对方操作...", "");
       }
-    } else if (!gameState.teamAssigned) {
-      // PVP - show 玩家1 / 玩家2 instead of color
-      showMessage("请翻开一张牌", "");
-    } else {
+    } else if (gameState.teamAssigned) {
       const sidesOrder = gameState.firstPlayer
         ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
         : ["red", "blue"];
       const idx = sidesOrder.indexOf(gameState.currentTeam);
       const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
       showMessage(playerName + "的回合", "");
+    } else {
+      // PVP - show 玩家1 / 玩家2 instead of color
+      showMessage("请翻开一张牌", "");
     }
   }
 

--- a/apps/card-game/animal-chess/game.js
+++ b/apps/card-game/animal-chess/game.js
@@ -952,18 +952,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage(gameState.currentTeam === localTeam ? "你的回合" : "等待对方操作...", "");
       }
-    } else {
+    } else if (!gameState.teamAssigned) {
       // PVP - show 玩家1 / 玩家2 instead of color
-      if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
-        const sidesOrder = gameState.firstPlayer
-          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
-          : ["red", "blue"];
-        const idx = sidesOrder.indexOf(gameState.currentTeam);
-        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
-        showMessage(playerName + "的回合", "");
-      }
+      showMessage("请翻开一张牌", "");
+    } else {
+      const sidesOrder = gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"];
+      const idx = sidesOrder.indexOf(gameState.currentTeam);
+      const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+      showMessage(playerName + "的回合", "");
     }
   }
 

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -945,18 +945,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage(gameState.currentTeam === localTeam ? "你的回合" : "等待对方操作...", "");
       }
-    } else {
+    } else if (!gameState.teamAssigned) {
       // PVP - show 玩家1 / 玩家2 instead of color
-      if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
-        const sidesOrder = gameState.firstPlayer
-          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
-          : ["red", "blue"];
-        const idx = sidesOrder.indexOf(gameState.currentTeam);
-        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
-        showMessage(playerName + "的回合", "");
-      }
+      showMessage("请翻开一张牌", "");
+    } else {
+      const sidesOrder = gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"];
+      const idx = sidesOrder.indexOf(gameState.currentTeam);
+      const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+      showMessage(playerName + "的回合", "");
     }
   }
 

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -941,16 +941,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage(gameState.currentTeam === localTeam ? "你的回合" : "等待对方操作...", "");
       }
-    } else if (!gameState.teamAssigned) {
-      // PVP - show 玩家1 / 玩家2 instead of color
-      showMessage("请翻开一张牌", "");
-    } else {
+    } else if (gameState.teamAssigned) {
       const sidesOrder = gameState.firstPlayer
         ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
         : ["red", "blue"];
       const idx = sidesOrder.indexOf(gameState.currentTeam);
       const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
       showMessage(playerName + "的回合", "");
+    } else {
+      // PVP - show 玩家1 / 玩家2 instead of color
+      showMessage("请翻开一张牌", "");
     }
   }
 

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -1046,8 +1046,12 @@ if (typeof document !== "undefined") {
         }
         handleOnlineRPSResult({ result: "draw" });
       } else {
-        const winnerRole =
-          result === 1 ? localPlayerRole : localPlayerRole === "host" ? "guest" : "host";
+        let winnerRole;
+        if (result === 1) {
+          winnerRole = localPlayerRole;
+        } else {
+          winnerRole = localPlayerRole === "host" ? "guest" : "host";
+        }
         const rpsResult = { result: "win", winner: winnerRole };
         if (networkProtocol) {
           networkProtocol.sendRPSResult(rpsResult);

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -835,7 +835,6 @@ if (typeof document !== "undefined") {
     // Click opponent face-up card (no selection)
     if (card && card.faceUp && card.team !== currentTeam) {
       showMessage("这不是你的棋子", "error");
-      return;
     }
   });
 

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -96,12 +96,10 @@ function createGameState(mode) {
 
   // Create 16 pieces: 8 red + 8 blue
   const cards = [];
-  for (let i = 0; i < PIECE_NAMES.length; i++) {
-    const name = PIECE_NAMES[i];
+  for (const name of PIECE_NAMES) {
     cards.push({ name: name, team: "red", rank: RANK_MAP[name], faceUp: false });
   }
-  for (let i = 0; i < PIECE_NAMES.length; i++) {
-    const name = PIECE_NAMES[i];
+  for (const name of PIECE_NAMES) {
     cards.push({ name: name, team: "blue", rank: RANK_MAP[name], faceUp: false });
   }
 
@@ -450,12 +448,12 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (let i = 0; i < moveTargets.length; i++) {
-      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (const t of moveTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (let j = 0; j < captureTargets.length; j++) {
-      const cc = getCell(captureTargets[j].x, captureTargets[j].y);
+    for (const t of captureTargets) {
+      const cc = getCell(t.x, t.y);
       if (cc) cc.classList.add("cell-capture-target");
     }
   }
@@ -519,8 +517,7 @@ if (typeof document !== "undefined") {
 
     // Captured cards
     $capturedRed.innerHTML = "";
-    for (let i = 0; i < state.capturedRed.length; i++) {
-      const nameR = state.capturedRed[i];
+    for (const nameR of state.capturedRed) {
       const divR = document.createElement("div");
       divR.className = "captured-card";
       const imgR = document.createElement("img");
@@ -531,8 +528,7 @@ if (typeof document !== "undefined") {
     }
 
     $capturedBlue.innerHTML = "";
-    for (let k = 0; k < state.capturedBlue.length; k++) {
-      const nameB = state.capturedBlue[k];
+    for (const nameB of state.capturedBlue) {
       const divB = document.createElement("div");
       divB.className = "captured-card";
       const imgB = document.createElement("img");

--- a/apps/card-game/cat-and-mouse/game.js
+++ b/apps/card-game/cat-and-mouse/game.js
@@ -96,12 +96,12 @@ function createGameState(mode) {
 
   // Create 16 pieces: 8 red + 8 blue
   const cards = [];
-  for (var i = 0; i < PIECE_NAMES.length; i++) {
-    var name = PIECE_NAMES[i];
+  for (let i = 0; i < PIECE_NAMES.length; i++) {
+    const name = PIECE_NAMES[i];
     cards.push({ name: name, team: "red", rank: RANK_MAP[name], faceUp: false });
   }
-  for (var i = 0; i < PIECE_NAMES.length; i++) {
-    var name = PIECE_NAMES[i];
+  for (let i = 0; i < PIECE_NAMES.length; i++) {
+    const name = PIECE_NAMES[i];
     cards.push({ name: name, team: "blue", rank: RANK_MAP[name], faceUp: false });
   }
 
@@ -584,8 +584,8 @@ if (typeof document !== "undefined") {
 
   // ---- 4.5 PVP Rock-Paper-Scissors button events ----
 
-  var rpsP1Choice = null;
-  var rpsP2Choice = null;
+  let rpsP1Choice = null;
+  let rpsP2Choice = null;
 
   document.querySelectorAll("#rps-pvp .btn-rps").forEach((btn) => {
     btn.addEventListener("click", () => {

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1647,8 +1647,12 @@ if (typeof document !== "undefined") {
         }
         handleOnlineRPSResult({ result: "draw" });
       } else {
-        const winnerRole =
-          result === 1 ? localPlayerRole : localPlayerRole === "host" ? "guest" : "host";
+        let winnerRole;
+        if (result === 1) {
+          winnerRole = localPlayerRole;
+        } else {
+          winnerRole = localPlayerRole === "host" ? "guest" : "host";
+        }
         const rpsResult = { result: "win", winner: winnerRole };
         if (networkProtocol) {
           networkProtocol.sendRPSResult(rpsResult);

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1471,16 +1471,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("你的回合", "");
       }
-    } else if (!gameState.teamAssigned) {
-      // PVP - show 玩家1 / 玩家2 instead of color
-      showMessage("请翻开一张牌", "");
-    } else {
+    } else if (gameState.teamAssigned) {
       const sidesOrder = gameState.firstPlayer
         ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
         : ["red", "blue"];
       const idx = sidesOrder.indexOf(gameState.currentTeam);
       const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
       showMessage(playerName + "的回合", "");
+    } else {
+      // PVP - show 玩家1 / 玩家2 instead of color
+      showMessage("请翻开一张牌", "");
     }
   }
 

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1474,18 +1474,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("你的回合", "");
       }
-    } else {
+    } else if (!gameState.teamAssigned) {
       // PVP - show 玩家1 / 玩家2 instead of color
-      if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
-        const sidesOrder = gameState.firstPlayer
-          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
-          : ["red", "blue"];
-        const idx = sidesOrder.indexOf(gameState.currentTeam);
-        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
-        showMessage(playerName + "的回合", "");
-      }
+      showMessage("请翻开一张牌", "");
+    } else {
+      const sidesOrder = gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"];
+      const idx = sidesOrder.indexOf(gameState.currentTeam);
+      const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+      showMessage(playerName + "的回合", "");
     }
   }
 

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1011,8 +1011,7 @@ if (typeof document !== "undefined") {
 
     // Captured piece images
     $capturedRed.innerHTML = "";
-    for (let i = 0; i < state.capturedRed.length; i++) {
-      const name = state.capturedRed[i];
+    for (const name of state.capturedRed) {
       const div = document.createElement("div");
       div.className = "captured-card";
       const img = document.createElement("img");
@@ -1023,8 +1022,7 @@ if (typeof document !== "undefined") {
     }
 
     $capturedBlue.innerHTML = "";
-    for (let i = 0; i < state.capturedBlue.length; i++) {
-      const name = state.capturedBlue[i];
+    for (const name of state.capturedBlue) {
       const div = document.createElement("div");
       div.className = "captured-card";
       const img = document.createElement("img");
@@ -1079,8 +1077,7 @@ if (typeof document !== "undefined") {
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
 
-    for (let i = 0; i < moveTargets.length; i++) {
-      const t = moveTargets[i];
+    for (const t of moveTargets) {
       const tc = getCell(t.x, t.y);
       if (tc) {
         if (t.type === "capture_flag") {
@@ -1091,8 +1088,8 @@ if (typeof document !== "undefined") {
       }
     }
 
-    for (let i = 0; i < captureTargets.length; i++) {
-      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (const t of captureTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-capture-target");
     }
   }

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1251,7 +1251,6 @@ if (typeof document !== "undefined") {
 
     if (piece && piece.faceUp && piece.team !== currentTeam) {
       showMessage("这不是你的棋子", "error");
-      return;
     }
   });
 

--- a/apps/card-game/chinese-army-chess/game.js
+++ b/apps/card-game/chinese-army-chess/game.js
@@ -1011,11 +1011,11 @@ if (typeof document !== "undefined") {
 
     // Captured piece images
     $capturedRed.innerHTML = "";
-    for (var i = 0; i < state.capturedRed.length; i++) {
-      var name = state.capturedRed[i];
-      var div = document.createElement("div");
+    for (let i = 0; i < state.capturedRed.length; i++) {
+      const name = state.capturedRed[i];
+      const div = document.createElement("div");
       div.className = "captured-card";
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.src = getImagePath({ name: name, team: "red", rank: getRank(name), faceUp: true });
       img.alt = name;
       div.appendChild(img);
@@ -1023,11 +1023,11 @@ if (typeof document !== "undefined") {
     }
 
     $capturedBlue.innerHTML = "";
-    for (var i = 0; i < state.capturedBlue.length; i++) {
-      var name = state.capturedBlue[i];
-      var div = document.createElement("div");
+    for (let i = 0; i < state.capturedBlue.length; i++) {
+      const name = state.capturedBlue[i];
+      const div = document.createElement("div");
       div.className = "captured-card";
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.src = getImagePath({ name: name, team: "blue", rank: getRank(name), faceUp: true });
       img.alt = name;
       div.appendChild(img);
@@ -1079,9 +1079,9 @@ if (typeof document !== "undefined") {
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
 
-    for (var i = 0; i < moveTargets.length; i++) {
+    for (let i = 0; i < moveTargets.length; i++) {
       const t = moveTargets[i];
-      var tc = getCell(t.x, t.y);
+      const tc = getCell(t.x, t.y);
       if (tc) {
         if (t.type === "capture_flag") {
           tc.classList.add("cell-flag-target");
@@ -1091,8 +1091,8 @@ if (typeof document !== "undefined") {
       }
     }
 
-    for (var i = 0; i < captureTargets.length; i++) {
-      var tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (let i = 0; i < captureTargets.length; i++) {
+      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
       if (tc) tc.classList.add("cell-capture-target");
     }
   }
@@ -1150,7 +1150,7 @@ if (typeof document !== "undefined") {
 
       // Click face-up flag: try to capture flag (moveCard)
       if (piece && piece.faceUp && isFlag(piece.name)) {
-        var result = moveCard(gameState, { x: sel.x, y: sel.y }, { x: x, y: y });
+        const result = moveCard(gameState, { x: sel.x, y: sel.y }, { x: x, y: y });
         if (result) {
           gameState.selectedCell = null;
           clearHighlights();
@@ -1170,7 +1170,7 @@ if (typeof document !== "undefined") {
         const captures = getValidCaptures(gameState.board, sel.x, sel.y, currentTeam);
         const canDo = captures.some((t) => t.x === x && t.y === y);
         if (canDo) {
-          var result = captureCard(gameState, { x: sel.x, y: sel.y }, { x: x, y: y });
+          const result = captureCard(gameState, { x: sel.x, y: sel.y }, { x: x, y: y });
           if (result) {
             gameState.selectedCell = null;
             clearHighlights();
@@ -1188,7 +1188,7 @@ if (typeof document !== "undefined") {
 
       // Click empty cell: try move
       if (!piece) {
-        var result = moveCard(gameState, { x: sel.x, y: sel.y }, { x: x, y: y });
+        const result = moveCard(gameState, { x: sel.x, y: sel.y }, { x: x, y: y });
         if (result) {
           gameState.selectedCell = null;
           clearHighlights();
@@ -1218,7 +1218,7 @@ if (typeof document !== "undefined") {
     // No piece selected
     if (piece && !piece.faceUp) {
       // Click face-down piece: flip
-      var result = flipCard(gameState, x, y);
+      const result = flipCard(gameState, x, y);
       if (result) {
         clearHighlights();
         // In online mode, assign teams on first non-flag flip
@@ -1331,8 +1331,8 @@ if (typeof document !== "undefined") {
     }
   }
 
-  var rpsP1Choice = null;
-  var rpsP2Choice = null;
+  let rpsP1Choice = null;
+  let rpsP2Choice = null;
 
   function handleRPSResult(choice1, choice2, mode) {
     const result = judgeRPS(choice1, choice2);

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -524,12 +524,12 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (let i = 0; i < moveTargets.length; i++) {
-      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (const t of moveTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (let i = 0; i < captureTargets.length; i++) {
-      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (const t of captureTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-capture-target");
     }
   }
@@ -583,8 +583,7 @@ if (typeof document !== "undefined") {
 
     // Captured cards
     $capturedDragon.innerHTML = "";
-    for (let i = 0; i < state.capturedDragon.length; i++) {
-      const piece = state.capturedDragon[i];
+    for (const piece of state.capturedDragon) {
       const div = document.createElement("div");
       div.className = "captured-card";
       const img = document.createElement("img");
@@ -595,8 +594,7 @@ if (typeof document !== "undefined") {
     }
 
     $capturedTiger.innerHTML = "";
-    for (let i = 0; i < state.capturedTiger.length; i++) {
-      const piece = state.capturedTiger[i];
+    for (const piece of state.capturedTiger) {
       const div = document.createElement("div");
       div.className = "captured-card";
       const img = document.createElement("img");

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -524,12 +524,12 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (var i = 0; i < moveTargets.length; i++) {
-      var tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (let i = 0; i < moveTargets.length; i++) {
+      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (var i = 0; i < captureTargets.length; i++) {
-      var tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (let i = 0; i < captureTargets.length; i++) {
+      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
       if (tc) tc.classList.add("cell-capture-target");
     }
   }
@@ -583,11 +583,11 @@ if (typeof document !== "undefined") {
 
     // Captured cards
     $capturedDragon.innerHTML = "";
-    for (var i = 0; i < state.capturedDragon.length; i++) {
-      var piece = state.capturedDragon[i];
-      var div = document.createElement("div");
+    for (let i = 0; i < state.capturedDragon.length; i++) {
+      const piece = state.capturedDragon[i];
+      const div = document.createElement("div");
       div.className = "captured-card";
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.src = getImagePath(piece);
       img.alt = piece;
       div.appendChild(img);
@@ -595,11 +595,11 @@ if (typeof document !== "undefined") {
     }
 
     $capturedTiger.innerHTML = "";
-    for (var i = 0; i < state.capturedTiger.length; i++) {
-      var piece = state.capturedTiger[i];
-      var div = document.createElement("div");
+    for (let i = 0; i < state.capturedTiger.length; i++) {
+      const piece = state.capturedTiger[i];
+      const div = document.createElement("div");
       div.className = "captured-card";
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.src = getImagePath(piece);
       img.alt = piece;
       div.appendChild(img);
@@ -891,8 +891,8 @@ if (typeof document !== "undefined") {
   }
 
   // --- Rock-Paper-Scissors logic ---
-  var rpsP1Choice = null;
-  var rpsP2Choice = null;
+  let rpsP1Choice = null;
+  let rpsP2Choice = null;
 
   function startGame(firstTeam) {
     showGameArea();

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -726,8 +726,12 @@ if (typeof document !== "undefined") {
         }
         handleOnlineRPSResult({ result: "draw" });
       } else {
-        const winnerRole =
-          result === 1 ? localPlayerRole : localPlayerRole === "host" ? "guest" : "host";
+        let winnerRole;
+        if (result === 1) {
+          winnerRole = localPlayerRole;
+        } else {
+          winnerRole = localPlayerRole === "host" ? "guest" : "host";
+        }
         const rpsResult = { result: "win", winner: winnerRole };
         if (networkProtocol) {
           networkProtocol.sendRPSResult(rpsResult);

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -1217,16 +1217,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("等待对方操作...", "info");
       }
-    } else if (!gameState.teamAssigned) {
-      // PVP - show 玩家1 / 玩家2 instead of dragon/tiger
-      showMessage("请翻开一张牌", "");
-    } else {
+    } else if (gameState.teamAssigned) {
       const sidesOrder = gameState.firstPlayer
         ? [gameState.firstPlayer, gameState.firstPlayer === "dragon" ? "tiger" : "dragon"]
         : ["dragon", "tiger"];
       const idx = sidesOrder.indexOf(gameState.currentTeam);
       const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
       showMessage(playerName + "的回合", "");
+    } else {
+      // PVP - show 玩家1 / 玩家2 instead of dragon/tiger
+      showMessage("请翻开一张牌", "");
     }
   }
 

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -1167,7 +1167,6 @@ if (typeof document !== "undefined") {
     // Click opponent face-up card (no selection)
     if (card && card.faceUp && card.team !== currentTeam) {
       showMessage("这不是你的棋子", "error");
-      return;
     }
   });
 

--- a/apps/card-game/dragon-tiger-fight/game.js
+++ b/apps/card-game/dragon-tiger-fight/game.js
@@ -1215,18 +1215,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("等待对方操作...", "info");
       }
-    } else {
+    } else if (!gameState.teamAssigned) {
       // PVP - show 玩家1 / 玩家2 instead of dragon/tiger
-      if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
-        const sidesOrder = gameState.firstPlayer
-          ? [gameState.firstPlayer, gameState.firstPlayer === "dragon" ? "tiger" : "dragon"]
-          : ["dragon", "tiger"];
-        const idx = sidesOrder.indexOf(gameState.currentTeam);
-        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
-        showMessage(playerName + "的回合", "");
-      }
+      showMessage("请翻开一张牌", "");
+    } else {
+      const sidesOrder = gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "dragon" ? "tiger" : "dragon"]
+        : ["dragon", "tiger"];
+      const idx = sidesOrder.indexOf(gameState.currentTeam);
+      const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+      showMessage(playerName + "的回合", "");
     }
   }
 

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -120,8 +120,7 @@ function createGameState(mode) {
 
   // Generate 16 cards: 8 red + 8 blue, one of each role per side
   const cards = [];
-  for (let i = 0; i < ROLES.length; i++) {
-    const role = ROLES[i];
+  for (const role of ROLES) {
     cards.push(
       { role: role, team: "red", faceUp: false, carrying: null },
       { role: role, team: "blue", faceUp: false, carrying: null }
@@ -686,16 +685,16 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (let i = 0; i < moveTargets.length; i++) {
-      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (const t of moveTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (let i = 0; i < captureTargets.length; i++) {
-      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (const t of captureTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-capture-target");
     }
-    for (let i = 0; i < carryTargets.length; i++) {
-      const tc = getCell(carryTargets[i].x, carryTargets[i].y);
+    for (const t of carryTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-carry-target");
     }
   }

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -686,16 +686,16 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (var i = 0; i < moveTargets.length; i++) {
-      var tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (let i = 0; i < moveTargets.length; i++) {
+      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (var i = 0; i < captureTargets.length; i++) {
-      var tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (let i = 0; i < captureTargets.length; i++) {
+      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
       if (tc) tc.classList.add("cell-capture-target");
     }
-    for (var i = 0; i < carryTargets.length; i++) {
-      var tc = getCell(carryTargets[i].x, carryTargets[i].y);
+    for (let i = 0; i < carryTargets.length; i++) {
+      const tc = getCell(carryTargets[i].x, carryTargets[i].y);
       if (tc) tc.classList.add("cell-carry-target");
     }
   }

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -122,8 +122,10 @@ function createGameState(mode) {
   const cards = [];
   for (let i = 0; i < ROLES.length; i++) {
     const role = ROLES[i];
-    cards.push({ role: role, team: "red", faceUp: false, carrying: null });
-    cards.push({ role: role, team: "blue", faceUp: false, carrying: null });
+    cards.push(
+      { role: role, team: "red", faceUp: false, carrying: null },
+      { role: role, team: "blue", faceUp: false, carrying: null }
+    );
   }
 
   // Fisher-Yates shuffle

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -1204,16 +1204,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("你的回合", "");
       }
-    } else if (!gameState.teamAssigned) {
-      // PVP - show 玩家1 / 玩家2 instead of color
-      showMessage("请翻开一张牌", "");
-    } else {
+    } else if (gameState.teamAssigned) {
       const sidesOrder = gameState.firstPlayer
         ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
         : ["red", "blue"];
       const idx = sidesOrder.indexOf(gameState.currentTeam);
       const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
       showMessage(playerName + "的回合", "");
+    } else {
+      // PVP - show 玩家1 / 玩家2 instead of color
+      showMessage("请翻开一张牌", "");
     }
   }
 

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -1144,7 +1144,6 @@ if (typeof document !== "undefined") {
     // Click opponent face-up card (no selection)
     if (card && card.faceUp && card.team !== currentTeam) {
       showMessage("这不是你的棋子", "error");
-      return;
     }
   });
 

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -1402,8 +1402,12 @@ if (typeof document !== "undefined") {
         }
         handleOnlineRPSResult({ result: "draw" });
       } else {
-        const winnerRole =
-          result === 1 ? localPlayerRole : localPlayerRole === "host" ? "guest" : "host";
+        let winnerRole;
+        if (result === 1) {
+          winnerRole = localPlayerRole;
+        } else {
+          winnerRole = localPlayerRole === "host" ? "guest" : "host";
+        }
         const rpsResult = { result: "win", winner: winnerRole };
         if (networkProtocol) {
           networkProtocol.sendRPSResult(rpsResult);

--- a/apps/card-game/knife-kills-chicken/game.js
+++ b/apps/card-game/knife-kills-chicken/game.js
@@ -1205,18 +1205,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("你的回合", "");
       }
-    } else {
+    } else if (!gameState.teamAssigned) {
       // PVP - show 玩家1 / 玩家2 instead of color
-      if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
-        const sidesOrder = gameState.firstPlayer
-          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
-          : ["red", "blue"];
-        const idx = sidesOrder.indexOf(gameState.currentTeam);
-        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
-        showMessage(playerName + "的回合", "");
-      }
+      showMessage("请翻开一张牌", "");
+    } else {
+      const sidesOrder = gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"];
+      const idx = sidesOrder.indexOf(gameState.currentTeam);
+      const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+      showMessage(playerName + "的回合", "");
     }
   }
 

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -943,18 +943,16 @@ if (typeof document !== "undefined") {
       } else {
         showMessage("你的回合", "");
       }
-    } else {
+    } else if (!gameState.teamAssigned) {
       // PVP - show 玩家1 / 玩家2 instead of color
-      if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
-        const sidesOrder = gameState.firstPlayer
-          ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
-          : ["red", "blue"];
-        const idx = sidesOrder.indexOf(gameState.currentTeam);
-        const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
-        showMessage(playerName + "的回合", "");
-      }
+      showMessage("请翻开一张牌", "");
+    } else {
+      const sidesOrder = gameState.firstPlayer
+        ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
+        : ["red", "blue"];
+      const idx = sidesOrder.indexOf(gameState.currentTeam);
+      const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
+      showMessage(playerName + "的回合", "");
     }
   }
 

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -106,12 +106,10 @@ function createGameState(mode) {
 
   // Create 16 pieces: 8 red + 8 blue
   const cards = [];
-  for (let i = 0; i < PIECE_NAMES.length; i++) {
-    const name = PIECE_NAMES[i];
+  for (const name of PIECE_NAMES) {
     cards.push({ name: name, team: "red", rank: RANK_MAP[name], faceUp: false });
   }
-  for (let i = 0; i < PIECE_NAMES.length; i++) {
-    const name = PIECE_NAMES[i];
+  for (const name of PIECE_NAMES) {
     cards.push({ name: name, team: "blue", rank: RANK_MAP[name], faceUp: false });
   }
 
@@ -450,12 +448,12 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (let i = 0; i < moveTargets.length; i++) {
-      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (const t of moveTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (let i = 0; i < captureTargets.length; i++) {
-      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (const t of captureTargets) {
+      const tc = getCell(t.x, t.y);
       if (tc) tc.classList.add("cell-capture-target");
     }
   }
@@ -514,8 +512,7 @@ if (typeof document !== "undefined") {
 
     // Captured pieces
     $capturedRed.innerHTML = "";
-    for (let i = 0; i < state.capturedRed.length; i++) {
-      const name = state.capturedRed[i];
+    for (const name of state.capturedRed) {
       const div = document.createElement("div");
       div.className = "captured-card";
       const img = document.createElement("img");
@@ -526,8 +523,7 @@ if (typeof document !== "undefined") {
     }
 
     $capturedBlue.innerHTML = "";
-    for (let i = 0; i < state.capturedBlue.length; i++) {
-      const name = state.capturedBlue[i];
+    for (const name of state.capturedBlue) {
       const div = document.createElement("div");
       div.className = "captured-card";
       const img = document.createElement("img");

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -1044,8 +1044,12 @@ if (typeof document !== "undefined") {
         }
         handleOnlineRPSResult({ result: "draw" });
       } else {
-        const winnerRole =
-          result === 1 ? localPlayerRole : localPlayerRole === "host" ? "guest" : "host";
+        let winnerRole;
+        if (result === 1) {
+          winnerRole = localPlayerRole;
+        } else {
+          winnerRole = localPlayerRole === "host" ? "guest" : "host";
+        }
         const rpsResult = { result: "win", winner: winnerRole };
         if (networkProtocol) {
           networkProtocol.sendRPSResult(rpsResult);

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -106,12 +106,12 @@ function createGameState(mode) {
 
   // Create 16 pieces: 8 red + 8 blue
   const cards = [];
-  for (var i = 0; i < PIECE_NAMES.length; i++) {
-    var name = PIECE_NAMES[i];
+  for (let i = 0; i < PIECE_NAMES.length; i++) {
+    const name = PIECE_NAMES[i];
     cards.push({ name: name, team: "red", rank: RANK_MAP[name], faceUp: false });
   }
-  for (var i = 0; i < PIECE_NAMES.length; i++) {
-    var name = PIECE_NAMES[i];
+  for (let i = 0; i < PIECE_NAMES.length; i++) {
+    const name = PIECE_NAMES[i];
     cards.push({ name: name, team: "blue", rank: RANK_MAP[name], faceUp: false });
   }
 
@@ -450,12 +450,12 @@ if (typeof document !== "undefined") {
     clearHighlights();
     const selected = getCell(x, y);
     if (selected) selected.classList.add("cell-selected");
-    for (var i = 0; i < moveTargets.length; i++) {
-      var tc = getCell(moveTargets[i].x, moveTargets[i].y);
+    for (let i = 0; i < moveTargets.length; i++) {
+      const tc = getCell(moveTargets[i].x, moveTargets[i].y);
       if (tc) tc.classList.add("cell-target");
     }
-    for (var i = 0; i < captureTargets.length; i++) {
-      var tc = getCell(captureTargets[i].x, captureTargets[i].y);
+    for (let i = 0; i < captureTargets.length; i++) {
+      const tc = getCell(captureTargets[i].x, captureTargets[i].y);
       if (tc) tc.classList.add("cell-capture-target");
     }
   }
@@ -514,11 +514,11 @@ if (typeof document !== "undefined") {
 
     // Captured pieces
     $capturedRed.innerHTML = "";
-    for (var i = 0; i < state.capturedRed.length; i++) {
-      var name = state.capturedRed[i];
-      var div = document.createElement("div");
+    for (let i = 0; i < state.capturedRed.length; i++) {
+      const name = state.capturedRed[i];
+      const div = document.createElement("div");
       div.className = "captured-card";
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.src = getImagePath("red", name);
       img.alt = name;
       div.appendChild(img);
@@ -526,11 +526,11 @@ if (typeof document !== "undefined") {
     }
 
     $capturedBlue.innerHTML = "";
-    for (var i = 0; i < state.capturedBlue.length; i++) {
-      var name = state.capturedBlue[i];
-      var div = document.createElement("div");
+    for (let i = 0; i < state.capturedBlue.length; i++) {
+      const name = state.capturedBlue[i];
+      const div = document.createElement("div");
       div.className = "captured-card";
-      var img = document.createElement("img");
+      const img = document.createElement("img");
       img.src = getImagePath("blue", name);
       img.alt = name;
       div.appendChild(img);
@@ -582,8 +582,8 @@ if (typeof document !== "undefined") {
 
   // ---- Rock-Paper-Scissors logic ----
 
-  var rpsP1Choice = null;
-  var rpsP2Choice = null;
+  let rpsP1Choice = null;
+  let rpsP2Choice = null;
 
   function startGame(firstTeam) {
     showGameArea();

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -934,21 +934,21 @@ if (typeof document !== "undefined") {
       if (gameState.teamAssigned && gameState.currentTeam === gameState.aiTeam) {
         // AI turn
         triggerAI();
-      } else if (!gameState.teamAssigned) {
-        showMessage("请翻开一张牌", "");
-      } else {
+      } else if (gameState.teamAssigned) {
         showMessage("你的回合", "");
+      } else {
+        showMessage("请翻开一张牌", "");
       }
-    } else if (!gameState.teamAssigned) {
-      // PVP - show 玩家1 / 玩家2 instead of color
-      showMessage("请翻开一张牌", "");
-    } else {
+    } else if (gameState.teamAssigned) {
       const sidesOrder = gameState.firstPlayer
         ? [gameState.firstPlayer, gameState.firstPlayer === "red" ? "blue" : "red"]
         : ["red", "blue"];
       const idx = sidesOrder.indexOf(gameState.currentTeam);
       const playerName = idx >= 0 ? "玩家" + (idx + 1) : "玩家";
       showMessage(playerName + "的回合", "");
+    } else {
+      // PVP - show 玩家1 / 玩家2 instead of color
+      showMessage("请翻开一张牌", "");
     }
   }
 

--- a/apps/card-game/little-emperor/game.js
+++ b/apps/card-game/little-emperor/game.js
@@ -830,7 +830,6 @@ if (typeof document !== "undefined") {
     // Click opponent face-up card (no selection)
     if (card && card.faceUp && card.team !== currentTeam) {
       showMessage("这不是你的棋子", "error");
-      return;
     }
   });
 

--- a/apps/childhood-board-game/bai-si-long/game.js
+++ b/apps/childhood-board-game/bai-si-long/game.js
@@ -465,10 +465,8 @@ if (typeof document !== "undefined") {
       var label = "";
       if (state.board[ny][nx] === PLAYER_A) {
         classes.push("node-a");
-        label = "";
       } else if (state.board[ny][nx] === PLAYER_B) {
         classes.push("node-b");
-        label = "";
       } else {
         classes.push("node-empty");
       }

--- a/apps/childhood-board-game/bai-si-long/game.js
+++ b/apps/childhood-board-game/bai-si-long/game.js
@@ -393,8 +393,8 @@ if (typeof document !== "undefined") {
         var pt = nodeToPx(x, y);
         var g = document.createElementNS(svgNS, "g");
         g.setAttribute("class", "node");
-        g.setAttribute("data-x", x);
-        g.setAttribute("data-y", y);
+        g.dataset.x = x;
+        g.dataset.y = y;
         g.setAttribute("transform", "translate(" + pt.cx + "," + pt.cy + ")");
 
         // Wide invisible hit area for easier tapping
@@ -459,8 +459,8 @@ if (typeof document !== "undefined") {
 
     var nodes = document.querySelectorAll("#board .node");
     nodes.forEach((g) => {
-      var nx = Number.parseInt(g.getAttribute("data-x"));
-      var ny = Number.parseInt(g.getAttribute("data-y"));
+      var nx = Number.parseInt(g.dataset.x);
+      var ny = Number.parseInt(g.dataset.y);
       var classes = ["node"];
       var label = "";
       if (state.board[ny][nx] === PLAYER_A) {

--- a/apps/childhood-board-game/bie-mao-keng/game.js
+++ b/apps/childhood-board-game/bie-mao-keng/game.js
@@ -355,7 +355,7 @@ if (typeof document !== "undefined") {
     for (var i = 0; i < TOTAL_POSITIONS; i++) {
       var g = document.createElementNS(svgNS, "g");
       g.setAttribute("class", "node");
-      g.setAttribute("data-pos", i);
+      g.dataset.pos = i;
       g.setAttribute("transform", "translate(" + POSITIONS[i].x + "," + POSITIONS[i].y + ")");
 
       var circle = document.createElementNS(svgNS, "circle");

--- a/apps/childhood-board-game/ma-yi-ban-jia/game.js
+++ b/apps/childhood-board-game/ma-yi-ban-jia/game.js
@@ -433,8 +433,8 @@ if (typeof document !== "undefined") {
         var pt2 = nodeToPx(x, y);
         var g = document.createElementNS(svgNS, "g");
         g.setAttribute("class", "node");
-        g.setAttribute("data-x", x);
-        g.setAttribute("data-y", y);
+        g.dataset.x = x;
+        g.dataset.y = y;
         g.setAttribute("transform", "translate(" + pt2.cx + "," + pt2.cy + ")");
 
         // Wide invisible hit area
@@ -496,8 +496,8 @@ if (typeof document !== "undefined") {
 
     var nodes = document.querySelectorAll("#board .node");
     nodes.forEach((g) => {
-      var nx = Number.parseInt(g.getAttribute("data-x"));
-      var ny = Number.parseInt(g.getAttribute("data-y"));
+      var nx = Number.parseInt(g.dataset.x);
+      var ny = Number.parseInt(g.dataset.y);
       var classes = ["node"];
       if (state.board[ny][nx] === PLAYER_A) classes.push("node-a");
       else if (state.board[ny][nx] === PLAYER_B) classes.push("node-b");

--- a/apps/childhood-board-game/si-bu-ding/game.js
+++ b/apps/childhood-board-game/si-bu-ding/game.js
@@ -434,8 +434,8 @@ if (typeof document !== "undefined") {
         var pt = nodeToPx(x, y);
         var g = document.createElementNS(svgNS, "g");
         g.setAttribute("class", "node");
-        g.setAttribute("data-x", x);
-        g.setAttribute("data-y", y);
+        g.dataset.x = x;
+        g.dataset.y = y;
         g.setAttribute("transform", "translate(" + pt.cx + "," + pt.cy + ")");
 
         var hit = document.createElementNS(svgNS, "circle");
@@ -487,8 +487,8 @@ if (typeof document !== "undefined") {
 
     var nodes = document.querySelectorAll("#board .node");
     nodes.forEach((g) => {
-      var nx = Number.parseInt(g.getAttribute("data-x"));
-      var ny = Number.parseInt(g.getAttribute("data-y"));
+      var nx = Number.parseInt(g.dataset.x);
+      var ny = Number.parseInt(g.dataset.y);
       var classes = ["node"];
       if (state.board[ny][nx] === PLAYER_A) classes.push("node-a");
       else if (state.board[ny][nx] === PLAYER_B) classes.push("node-b");

--- a/apps/childhood-board-game/xiao-mao-diao-yu/game.js
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/game.js
@@ -408,7 +408,7 @@ if (typeof document !== "undefined") {
 
       var g = document.createElementNS(svgNS, "g");
       g.setAttribute("class", "node");
-      g.setAttribute("data-pos", k);
+      g.dataset.pos = k;
       g.setAttribute("transform", "translate(" + cx + "," + cy + ")");
 
       var circle = document.createElementNS(svgNS, "circle");
@@ -458,7 +458,7 @@ if (typeof document !== "undefined") {
     }
 
     nodes.forEach((g) => {
-      var pos = Number.parseInt(g.getAttribute("data-pos"));
+      var pos = Number.parseInt(g.dataset.pos);
       var classes = ["node"];
       var label = "";
       if (state.board[pos] === PLAYER_A) {

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
@@ -463,7 +463,7 @@ if (typeof document !== "undefined") {
     for (var i = 0; i < TOTAL_POSITIONS; i++) {
       var g = document.createElementNS(svgNS, "g");
       g.setAttribute("class", "node");
-      g.setAttribute("data-pos", i);
+      g.dataset.pos = i;
       g.setAttribute("transform", "translate(" + POSITIONS[i].x + "," + POSITIONS[i].y + ")");
 
       var circle = document.createElementNS(svgNS, "circle");
@@ -511,7 +511,7 @@ if (typeof document !== "undefined") {
     }
 
     nodes.forEach((g) => {
-      var pos = Number.parseInt(g.getAttribute("data-pos"));
+      var pos = Number.parseInt(g.dataset.pos);
       var classes = ["node"];
       var label = "";
       if (state.board[pos] === PLAYER_A) {

--- a/apps/common/card-game-core.js
+++ b/apps/common/card-game-core.js
@@ -386,7 +386,7 @@ function chooseBestFlip(board, aiTeam, deps, size) {
       }
     }
     const distFromCenter = Math.abs(pos.x - center) + Math.abs(pos.y - center);
-    const score = adjEnemyCount * 0.5 - maxAdjOwnVal * 1.0 - distFromCenter * 0.1;
+    const score = adjEnemyCount * 0.5 - maxAdjOwnVal * 1 - distFromCenter * 0.1;
     return { pos, score };
   });
   scored.sort((a, b) => b.score - a.score);
@@ -527,7 +527,7 @@ function chooseBestMove(board, aiTeam, deps, size) {
 function smartAiDecide(state, aiTeam, deps) {
   // Wrap a legacy pieceValue(rank) signature so the new helpers can call
   // pieceValue(card, otherCard?, role?) uniformly.
-  const wrappedDeps = Object.assign({}, deps, { pieceValue: wrapPieceValue(deps.pieceValue) });
+  const wrappedDeps = { ...deps, pieceValue: wrapPieceValue(deps.pieceValue) };
   const board = state.board;
 
   const cap = chooseBestCapture(board, aiTeam, wrappedDeps);
@@ -578,7 +578,7 @@ function nearestEnemyDelta(board, fromX, fromY, to, ownTeam, size) {
       if (dAfter < bestAfter) bestAfter = dAfter;
     }
   }
-  if (!isFinite(bestBefore) || !isFinite(bestAfter)) return 0;
+  if (!Number.isFinite(bestBefore) || !Number.isFinite(bestAfter)) return 0;
   return bestBefore - bestAfter;
 }
 

--- a/apps/common/card-game-core.js
+++ b/apps/common/card-game-core.js
@@ -88,9 +88,9 @@ function getValidMoves(board, x, y) {
   const card = board[y][x];
   if (!card) return [];
   const moves = [];
-  for (let i = 0; i < DIRECTIONS.length; i++) {
-    const nx = x + DIRECTIONS[i].dx;
-    const ny = y + DIRECTIONS[i].dy;
+  for (const dir of DIRECTIONS) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
     if (inBounds(nx, ny) && board[ny][nx] === null) {
       moves.push({ x: nx, y: ny });
     }
@@ -231,9 +231,9 @@ function isPositionUnderThreat(board, x, y, ownTeam, canCaptureFn, inBoundsFn) {
   const card = board[y][x];
   if (!card || !card.faceUp) return false;
   const dims = _boardDims(board, inBoundsFn);
-  for (let i = 0; i < DIRECTIONS.length; i++) {
-    const nx = x + DIRECTIONS[i].dx;
-    const ny = y + DIRECTIONS[i].dy;
+  for (const dir of DIRECTIONS) {
+    const nx = x + dir.dx;
+    const ny = y + dir.dy;
     if (!dims.inBounds(nx, ny)) continue;
     const enemy = board[ny][nx];
     if (!enemy || !enemy.faceUp || enemy.team === ownTeam) continue;
@@ -372,9 +372,9 @@ function chooseBestFlip(board, aiTeam, deps, size) {
   const scored = faceDownCells.map((pos) => {
     let maxAdjOwnVal = 0;
     let adjEnemyCount = 0;
-    for (let i = 0; i < DIRECTIONS.length; i++) {
-      const nx = pos.x + DIRECTIONS[i].dx;
-      const ny = pos.y + DIRECTIONS[i].dy;
+    for (const dir of DIRECTIONS) {
+      const nx = pos.x + dir.dx;
+      const ny = pos.y + dir.dy;
       if (!dims.inBounds(nx, ny)) continue;
       const c = board[ny][nx];
       if (!c || !c.faceUp) continue;
@@ -450,9 +450,9 @@ function chooseBestMove(board, aiTeam, deps, size) {
         }
 
         let approachBonus = 0;
-        for (let i = 0; i < DIRECTIONS.length; i++) {
-          const nx = t.x + DIRECTIONS[i].dx;
-          const ny = t.y + DIRECTIONS[i].dy;
+        for (const dir of DIRECTIONS) {
+          const nx = t.x + dir.dx;
+          const ny = t.y + dir.dy;
           if (!dims.inBounds(nx, ny)) continue;
           const enemy = futureBoard[ny][nx];
           if (!enemy || !enemy.faceUp || enemy.team === aiTeam) continue;

--- a/apps/common/network-game-protocol.js
+++ b/apps/common/network-game-protocol.js
@@ -247,9 +247,9 @@ class NetworkGameProtocol {
   }
 }
 
-// Expose on window for browser use
-if (typeof window !== "undefined") {
-  window.NetworkGameProtocol = NetworkGameProtocol;
+// Expose on globalThis for browser use
+if (typeof globalThis.window !== "undefined") {
+  globalThis.NetworkGameProtocol = NetworkGameProtocol;
 }
 
 // Module exports for Node.js testing

--- a/apps/common/room-ui.js
+++ b/apps/common/room-ui.js
@@ -58,7 +58,7 @@ class RoomUI {
     this._destroyed = true;
     this._cleanupConnection();
     if (this._overlay && this._overlay.parentNode) {
-      this._overlay.parentNode.removeChild(this._overlay);
+      this._overlay.remove();
     }
     this._overlay = null;
   }
@@ -372,7 +372,7 @@ class RoomUI {
         document.body.appendChild(ta);
         ta.select();
         document.execCommand("copy");
-        document.body.removeChild(ta);
+        ta.remove();
       }
       const orig = button.textContent;
       button.textContent = "已复制!";

--- a/apps/common/room-ui.js
+++ b/apps/common/room-ui.js
@@ -385,9 +385,9 @@ class RoomUI {
   }
 }
 
-// Expose on window for browser use
-if (typeof window !== "undefined") {
-  window.RoomUI = RoomUI;
+// Expose on globalThis for browser use
+if (typeof globalThis.window !== "undefined") {
+  globalThis.RoomUI = RoomUI;
 }
 
 // Module exports for Node.js testing

--- a/apps/common/webrtc-connection.js
+++ b/apps/common/webrtc-connection.js
@@ -318,10 +318,10 @@ class WebRTCConnection {
   }
 }
 
-// Expose on window for browser use
-if (typeof window !== "undefined") {
-  window.WebRTCConnection = WebRTCConnection;
-  window._webrtcUtils = {
+// Expose on globalThis for browser use
+if (typeof globalThis.window !== "undefined") {
+  globalThis.WebRTCConnection = WebRTCConnection;
+  globalThis._webrtcUtils = {
     encodeRoomData,
     decodeRoomData,
     minimizeSdp,

--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -792,15 +792,13 @@ if (typeof $j !== "undefined") {
               .addClass("pointer");
             flag = true;
           }
-        } else {
-          if ($j(this).attr("state") == "ready" || $j(this).attr("state") == "running") {
-            currentUserPlane
-              .on("click", function () {
-                movePlane(this);
-              })
-              .addClass("pointer");
-            flag = true;
-          }
+        } else if ($j(this).attr("state") == "ready" || $j(this).attr("state") == "running") {
+          currentUserPlane
+            .on("click", function () {
+              movePlane(this);
+            })
+            .addClass("pointer");
+          flag = true;
         }
       }
     });

--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -393,14 +393,14 @@ if (typeof $j !== "undefined") {
   const WINMUSICURL = "audio/win_cheer.ogg";
   const FAILMUSICURL = "";
 
-  const PlaneAudio = function () {
-    function playMusic(musicSrc) {
-      if (planeOption.gameMusic) {
-        $j("#yinxiao").attr("src", musicSrc);
-        $j("#yinxiao")[0].play();
-      }
+  function playMusic(musicSrc) {
+    if (planeOption.gameMusic) {
+      $j("#yinxiao").attr("src", musicSrc);
+      $j("#yinxiao")[0].play();
     }
+  }
 
+  const PlaneAudio = function () {
     this.playDiceMusic = function () {
       playMusic(DICEMUSICURL);
     };
@@ -448,11 +448,12 @@ if (typeof $j !== "undefined") {
   const planeAudio = new PlaneAudio();
 
   // ---- Option ----
+  function PLANEUSER(color, state) {
+    this.color = color;
+    this.state = state;
+  }
+
   const PlaneOption = function () {
-    const PLANEUSER = function (color, state) {
-      this.color = color;
-      this.state = state;
-    };
     this.userList = [
       new PLANEUSER("red", "normal"),
       new PLANEUSER("blue", "computer"),
@@ -492,6 +493,14 @@ if (typeof $j !== "undefined") {
   const planeOption = new PlaneOption();
 
   // ---- Rule ----
+  function backCurrentUserAllPlane() {
+    $j(".plane").each(function () {
+      if (planeOption.currentUser == $j(this).attr("type")) {
+        rule.planeBack("attack", planeOption.currentUser, $j(this));
+      }
+    });
+  }
+
   const Rule = function () {
     this.victory = function () {
       let winNum = 0,
@@ -554,14 +563,6 @@ if (typeof $j !== "undefined") {
       }
     };
 
-    function backCurrentUserAllPlane() {
-      $j(".plane").each(function () {
-        if (planeOption.currentUser == $j(this).attr("type")) {
-          rule.planeBack("attack", planeOption.currentUser, $j(this));
-        }
-      });
-    }
-
     this.countSixTime = function () {
       if (diceNum == 6) {
         sixTime++;
@@ -622,6 +623,43 @@ if (typeof $j !== "undefined") {
   const rule = new Rule();
 
   // ---- Computer ----
+  function diceClick() {
+    const nextSt = setTimeout(() => {
+      if (nextStep) {
+        $j("#dice").trigger("click");
+        clearTimeout(nextSt);
+      } else {
+        diceClick();
+      }
+    }, 500);
+  }
+
+  function getComputerRandomIndex(leng) {
+    const num = Math.floor(Math.random() * 10);
+    switch (leng) {
+      case 1:
+        return 0;
+      case 2:
+        if (num == 0 || num == 1) {
+          return num;
+        } else {
+          return getComputerRandomIndex(leng);
+        }
+      case 3:
+        if (num == 0 || num == 1 || num == 2) {
+          return num;
+        } else {
+          return getComputerRandomIndex(leng);
+        }
+      case 4:
+        if (num == 0 || num == 1 || num == 2 || num == 3) {
+          return num;
+        } else {
+          return getComputerRandomIndex(leng);
+        }
+    }
+  }
+
   const Computer = function () {
     this.performing = function () {
       setTimeout(() => {
@@ -632,7 +670,7 @@ if (typeof $j !== "undefined") {
           }
         });
         if (planeList && planeList.length > 0) {
-          const randomNum = obtainRandomNum(planeList.length);
+          const randomNum = getComputerRandomIndex(planeList.length);
           $j(planeList[randomNum]).trigger("click");
           if (diceNum == 6) {
             diceClick();
@@ -640,43 +678,6 @@ if (typeof $j !== "undefined") {
         }
       }, 1500);
     };
-
-    function diceClick() {
-      const nextSt = setTimeout(() => {
-        if (nextStep) {
-          $j("#dice").trigger("click");
-          clearTimeout(nextSt);
-        } else {
-          diceClick();
-        }
-      }, 500);
-    }
-
-    function obtainRandomNum(leng) {
-      const num = Math.floor(Math.random() * 10);
-      switch (leng) {
-        case 1:
-          return 0;
-        case 2:
-          if (num == 0 || num == 1) {
-            return num;
-          } else {
-            return obtainRandomNum(leng);
-          }
-        case 3:
-          if (num == 0 || num == 1 || num == 2) {
-            return num;
-          } else {
-            return obtainRandomNum(leng);
-          }
-        case 4:
-          if (num == 0 || num == 1 || num == 2 || num == 3) {
-            return num;
-          } else {
-            return obtainRandomNum(leng);
-          }
-      }
-    }
   };
   const computer = new Computer();
 

--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -1297,19 +1297,17 @@ if (typeof $j !== "undefined") {
       // Remote player selects a plane
       if (planeOption.currentUser !== remoteColor) return;
       const pn = actionData.pn;
-      let targetPlane = null;
-      $j(".plane").each(function () {
-        if (
-          $j(this).attr("type") === remoteColor &&
-          $j(this).attr("num") == pn &&
-          $j(this).hasClass("pointer")
-        ) {
-          targetPlane = this;
-          return false; // break
-        }
-      });
-      if (targetPlane) {
-        $j(targetPlane).trigger("click");
+      const targetPlane = $j(".plane")
+        .filter(function () {
+          return (
+            $j(this).attr("type") === remoteColor &&
+            $j(this).attr("num") == pn &&
+            $j(this).hasClass("pointer")
+          );
+        })
+        .first();
+      if (targetPlane.length) {
+        targetPlane.trigger("click");
       }
     }
   }
@@ -1333,19 +1331,11 @@ if (typeof $j !== "undefined") {
     window.onkeydown = function (e) {
       if (e.which) {
         if (e.which == 116) {
-          if (confirm("确定刷新页面吗？刷新后页面数据将被清除！")) {
-            return true;
-          } else {
-            return false;
-          }
+          return confirm("确定刷新页面吗？刷新后页面数据将被清除！");
         }
       } else if (e.keyCode) {
         if (e.keyCode == 116) {
-          if (confirm("确定刷新页面吗？刷新后页面数据将被清除！")) {
-            return true;
-          } else {
-            return false;
-          }
+          return confirm("确定刷新页面吗？刷新后页面数据将被清除！");
         }
       }
     };

--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -646,7 +646,6 @@ if (typeof $j !== "undefined") {
         if (nextStep) {
           $j("#dice").trigger("click");
           clearTimeout(nextSt);
-          return;
         } else {
           diceClick();
         }

--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -182,9 +182,9 @@ function createDefaultUserList() {
  * @returns {string|undefined}
  */
 function userState(color, userList) {
-  for (let i = 0; i < userList.length; i++) {
-    if (color === userList[i].color) {
-      return userList[i].state;
+  for (const user of userList) {
+    if (color === user.color) {
+      return user.state;
     }
   }
   return undefined;
@@ -207,9 +207,9 @@ function getNextColor(currentColor) {
  * @returns {boolean}
  */
 function hasRelayMarker(coordId) {
-  for (let i = 0; i < COORD.length; i++) {
-    if (COORD[i].id == coordId) {
-      return COORD[i].r === "yes";
+  for (const c of COORD) {
+    if (c.id == coordId) {
+      return c.r === "yes";
     }
   }
   return false;
@@ -221,9 +221,9 @@ function hasRelayMarker(coordId) {
  * @returns {string|null}
  */
 function getSuperTarget(coordId) {
-  for (let i = 0; i < COORD.length; i++) {
-    if (COORD[i].id == coordId) {
-      return COORD[i].super || null;
+  for (const c of COORD) {
+    if (c.id == coordId) {
+      return c.super || null;
     }
   }
   return null;
@@ -293,8 +293,8 @@ function isWinCell(coordId) {
  */
 function checkVictory(planes, color) {
   let winCount = 0;
-  for (let i = 0; i < planes.length; i++) {
-    if (planes[i].type === color && planes[i].state === "win") {
+  for (const plane of planes) {
+    if (plane.type === color && plane.state === "win") {
       winCount++;
     }
   }
@@ -310,9 +310,9 @@ function checkVictory(planes, color) {
 function getInitCoord(color, planeNum) {
   const coords = INIT_COORDS[color];
   if (!coords) return null;
-  for (let i = 0; i < coords.length; i++) {
-    if (coords[i].id === planeNum) {
-      return { top: coords[i].top, left: coords[i].left };
+  for (const c of coords) {
+    if (c.id === planeNum) {
+      return { top: c.top, left: c.left };
     }
   }
   return null;
@@ -688,20 +688,20 @@ if (typeof $j !== "undefined") {
    */
   function createPlane(type) {
     if (type && type.length > 0) {
-      for (let i = 0; i < type.length; i++) {
-        if (type[i].state != "close") {
-          switch (type[i].color) {
+      for (const plane of type) {
+        if (plane.state != "close") {
+          switch (plane.color) {
             case "red":
-              addPlaneDiv(type[i].color, 73, 770);
+              addPlaneDiv(plane.color, 73, 770);
               break;
             case "blue":
-              addPlaneDiv(type[i].color, 771, 770);
+              addPlaneDiv(plane.color, 771, 770);
               break;
             case "yellow":
-              addPlaneDiv(type[i].color, 771, 71);
+              addPlaneDiv(plane.color, 771, 71);
               break;
             case "green":
-              addPlaneDiv(type[i].color, 73, 71);
+              addPlaneDiv(plane.color, 73, 71);
               break;
           }
         }
@@ -1012,9 +1012,9 @@ if (typeof $j !== "undefined") {
    */
   function userStateBrowser(color) {
     let state;
-    for (let i = 0; i < planeOption.userList.length; i++) {
-      if (color == planeOption.userList[i].color) {
-        state = planeOption.userList[i].state;
+    for (const user of planeOption.userList) {
+      if (color == user.color) {
+        state = user.state;
       }
     }
     return state;
@@ -1072,8 +1072,8 @@ if (typeof $j !== "undefined") {
     // Count totals first
     let humanTotal = 0;
     let aiTotal = 0;
-    for (let i = 0; i < planeOption.userList.length; i++) {
-      const st = planeOption.userList[i].state;
+    for (const user of planeOption.userList) {
+      const st = user.state;
       if (st === "normal") humanTotal++;
       else if (st === "computer") aiTotal++;
     }
@@ -1081,8 +1081,7 @@ if (typeof $j !== "undefined") {
     let humanIdx = 0;
     let aiIdx = 0;
     let currentLabel = "玩家";
-    for (let i = 0; i < planeOption.userList.length; i++) {
-      const user = planeOption.userList[i];
+    for (const user of planeOption.userList) {
       let label;
       if (user.state === "normal") {
         humanIdx++;


### PR DESCRIPTION
## SonarQube Issue Cleanup

Systematic fix of SonarQube findings. One commit per rule key.

### Fixes
| Commit | Rule key | Issue type | Fix approach |
| ------ | -------- | ---------- | ------------ |
| c01198d | javascript:S1481 | Unused local variable | Removed 11 unused variable declarations across 6 game files |
| d88ccca | javascript:S1854 | Useless assignment | Removed unused remoteTeam variable and dead loop in go/game.js |
| 4b2e48a | javascript:S3626 | Redundant return | Removed 8 redundant return statements at end of event handler callbacks |
| a029691 | javascript:S4030 | Unused collection | Removed unused opponents array in chinese-checkers |
| 9dc1176 | javascript:S4165 | Redundant assignment | Removed redundant label re-assignments in bai-si-long |
| 74c2067 | javascript:S7762 | Prefer remove() | Used childNode.remove() over parentNode.removeChild() |
| 4696155 | javascript:S2589 | Always truthy | Removed redundant hasMoved guard in castling logic |
| 84dcbe5 | javascript:S6661,S7748,S7773 | Modern JS | Object spread, remove zero fraction, Number.isFinite |
| 1dd6c07 | javascript:S7778 | Array#push | Combined multiple push calls into single call |
| 27154f9 | javascript:S1126,S7740 | Simplification | Direct return from confirm, jQuery .filter() instead of this assignment |
| 59ac85d | javascript:S7765 | Prefer includes() | Used .includes() instead of .indexOf() !== -1 |
| 44a49f7 | javascript:S7761 | Prefer dataset | Used .dataset over setAttribute/getAttribute for data-* attributes |
| d7714a1 | javascript:S6660 | else-if merge | Collapsed else { if } into else-if chains in 11 files |
| 804ce36 | javascript:S7764 | Prefer globalThis | Used globalThis over window for UMD exports |
| 51c790f | javascript:S3358 | Nested ternary | Extracted nested ternary operations into if-else in 13 files |
| 3b4e92a | javascript:S1874 | Deprecated API | Pass event parameter instead of using global event in 8 files |
| e24fcfd | javascript:S2814 | Redeclared var | Changed var to let/const across 13 files (283 lines) |
| bbd79a9 | javascript:S4138 | Prefer for-of | Converted ~115 simple iteration loops to for-of across 15 files |
| 87b76cf | javascript:S4138 | Prefer for-of | Converted 7 more for-i loops to for-of in 3 files |
| ec7f5a7 | javascript:S7735 | Negated condition | Inverted negated conditions in else-if chains across 7 files |
| 0a2f6c2 | javascript:S7721 | Move to outer scope | Moved 5 functions from inner constructor scope to outer scope |
| 5b90809 | javascript:S107 | Too many parameters | Grouped coordinates into object, reducing params from 8 to 5 |

### False positives / accepted
| Rule key | Where | Why | Action |
| -------- | ----- | --- | ------ |
| javascript:S7741 | Common modules | typeof x === "undefined" safely checks undeclared variables | Marked false positive in SonarCloud |
| css:S7924 | Multiple CSS files | Text contrast issues require design decisions | Accepted, skipping |
| javascript:S2392 | Multiple files | Side effect of var→let/const conversion; resolved by latest scan | No longer present |

### Verification
- `npm run lint` ✓ (0 errors, 41 warnings) · `npm test` ✓ (1652 tests pass)
- CI: `Childhood CI` ✓ · `SonarQube Analysis` ✓ · `CodeQL` ✓ · `GitGuardian` ✓
- Quality Gate on PR: OK · Coverage: 47.7% · No new issues introduced
