### PR TITLE
fix: unify AI label to 电脑 in user-facing text across all games

### DIFF
--- a/apps/board-game/checkers/game.js
+++ b/apps/board-game/checkers/game.js
@@ -598,9 +598,9 @@ if (typeof document !== "undefined") {
     if (state.gameOver) {
       updateMessage("游戏结束！", "info");
     } else if (state.aiThinking) {
-      updateMessage("AI正在思考...", "info");
+      updateMessage("电脑正在思考...", "info");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
-      updateMessage("轮到AI行动", "info");
+      updateMessage("轮到电脑行动", "info");
     } else if (state.multiJumpPiece) {
       updateMessage("可以继续吃子！", "info");
     } else if (state.mustCapture) {
@@ -1180,7 +1180,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(红方)。";
         setTimeout(() => {
@@ -1190,9 +1190,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(红方)。";
+          "，你输了！电脑先手(红方)。";
         setTimeout(() => {
           startGame("pve", WHITE);
         }, 1500);
@@ -1200,7 +1200,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/chinese-army-chess/game.js
+++ b/apps/board-game/chinese-army-chess/game.js
@@ -1798,7 +1798,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手。";
         setTimeout(() => {
@@ -1808,9 +1808,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手。";
+          "，你输了！电脑先手。";
         setTimeout(() => {
           startGame(pendingMode, BLUE);
         }, 1500);
@@ -1818,7 +1818,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/chinese-checkers/game.js
+++ b/apps/board-game/chinese-checkers/game.js
@@ -862,7 +862,7 @@ if (typeof document !== "undefined") {
 
   function triggerAI() {
     gameState.aiThinking = true;
-    updateMessage("AI正在思考...", "info");
+    updateMessage("电脑正在思考...", "info");
     setTimeout(() => {
       const move = getBestAIMove(gameState.board, gameState.aiTeam);
       gameState.aiThinking = false;
@@ -1215,7 +1215,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(" +
           PLAYER_COLORS[RED].name +
@@ -1227,9 +1227,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(" +
+          "，你输了！电脑先手(" +
           PLAYER_COLORS[BLUE].name +
           ")。";
         setTimeout(() => {
@@ -1239,7 +1239,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -919,9 +919,9 @@ if (typeof document !== "undefined") {
     if (state.gameOver) {
       updateMessage("游戏结束！", "info");
     } else if (state.aiThinking) {
-      updateMessage("AI正在思考...", "info");
+      updateMessage("电脑正在思考...", "info");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
-      updateMessage("轮到AI行动", "info");
+      updateMessage("轮到电脑行动", "info");
     } else {
       updateMessage("轮到 " + label.text + " 行动", "info");
     }
@@ -1328,7 +1328,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(红方)。";
         setTimeout(() => {
@@ -1338,9 +1338,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(红方)。";
+          "，你输了！电脑先手(红方)。";
         setTimeout(() => {
           startGame("pve", BLACK);
         }, 1500);
@@ -1348,7 +1348,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/go/game.js
+++ b/apps/board-game/go/game.js
@@ -802,9 +802,9 @@ if (typeof document !== "undefined") {
     if (state.gameOver) {
       updateMessage("游戏结束！", "info");
     } else if (state.aiThinking) {
-      updateMessage("AI正在思考...", "info");
+      updateMessage("电脑正在思考...", "info");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
-      updateMessage("轮到AI行动", "info");
+      updateMessage("轮到电脑行动", "info");
     } else {
       updateMessage("轮到 " + label.text + " 落子", "info");
     }
@@ -1253,7 +1253,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(黑棋)。";
         setTimeout(() => {
@@ -1263,9 +1263,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(黑棋)。";
+          "，你输了！电脑先手(黑棋)。";
         setTimeout(() => {
           startGame("pve", WHITE);
         }, 1500);
@@ -1273,7 +1273,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/gomoku/game.js
+++ b/apps/board-game/gomoku/game.js
@@ -453,9 +453,9 @@ if (typeof document !== "undefined") {
     if (state.gameOver) {
       updateMessage("游戏结束！", "info");
     } else if (state.aiThinking) {
-      updateMessage("AI正在思考...", "info");
+      updateMessage("电脑正在思考...", "info");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
-      updateMessage("轮到AI行动", "info");
+      updateMessage("轮到电脑行动", "info");
     } else {
       updateMessage("轮到 " + label.text + " 落子", "info");
     }
@@ -807,7 +807,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(黑棋)。";
         setTimeout(() => {
@@ -817,9 +817,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(黑棋)。";
+          "，你输了！电脑先手(黑棋)。";
         setTimeout(() => {
           startGame("pve", WHITE);
         }, 1500);
@@ -827,7 +827,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/international-chess/game.js
+++ b/apps/board-game/international-chess/game.js
@@ -994,9 +994,9 @@ if (typeof document !== "undefined") {
       document.getElementById("label-black").textContent = "黑方：";
     }
     if (state.gameOver) updateMessage("游戏结束！", "info");
-    else if (state.aiThinking) updateMessage("AI正在思考...", "info");
+    else if (state.aiThinking) updateMessage("电脑正在思考...", "info");
     else if (state.mode === "pve" && state.currentPlayer === state.aiTeam)
-      updateMessage("轮到AI行动", "info");
+      updateMessage("轮到电脑行动", "info");
     else if (state.promotionPending) updateMessage("选择升变棋子", "info");
     else updateMessage("轮到 " + label.text + " 行动", "info");
   }
@@ -1445,7 +1445,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(白方)。";
         setTimeout(() => {
@@ -1455,9 +1455,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(白方)。";
+          "，你输了！电脑先手(白方)。";
         setTimeout(() => {
           startGame("pve", BLACK);
         }, 1500);
@@ -1465,7 +1465,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/board-game/reversi/game.js
+++ b/apps/board-game/reversi/game.js
@@ -295,7 +295,7 @@ function aiTurn(state) {
   if (state.gameOver || state.currentPlayer !== state.aiTeam) return;
 
   state.aiThinking = true;
-  updateMessage("AI正在思考...", "info");
+  updateMessage("电脑正在思考...", "info");
 
   // Simulate AI thinking time
   setTimeout(() => {
@@ -483,9 +483,9 @@ function renderGame(state) {
       "info"
     );
   } else if (state.aiThinking) {
-    updateMessage("AI正在思考...", "info");
+    updateMessage("电脑正在思考...", "info");
   } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
-    updateMessage("轮到AI行动", "info");
+    updateMessage("轮到电脑行动", "info");
   } else {
     updateMessage(`轮到${state.currentPlayer === PLAYER_BLACK ? "黑棋" : "白棋"}行动`, "info");
   }
@@ -875,13 +875,13 @@ function handleRPSChoice(player, choice, ev) {
     const humanWins = judgeRPS(choice, aiChoice);
 
     if (humanWins === 1) {
-      resultElement.textContent = `你选择了${getRPSName(choice)}，AI选择了${getRPSName(aiChoice)}，你赢了！你先手。`;
+      resultElement.textContent = `你选择了${getRPSName(choice)}，电脑选择了${getRPSName(aiChoice)}，你赢了！你先手。`;
       setTimeout(() => startGame("pve", PLAYER_BLACK), 1500);
     } else if (humanWins === -1) {
-      resultElement.textContent = `你选择了${getRPSName(choice)}，AI选择了${getRPSName(aiChoice)}，你输了！AI先手。`;
+      resultElement.textContent = `你选择了${getRPSName(choice)}，电脑选择了${getRPSName(aiChoice)}，你输了！电脑先手。`;
       setTimeout(() => startGame("pve", PLAYER_WHITE), 1500);
     } else {
-      resultElement.textContent = `你选择了${getRPSName(choice)}，AI选择了${getRPSName(aiChoice)}，Draw！重新选择。`;
+      resultElement.textContent = `你选择了${getRPSName(choice)}，电脑选择了${getRPSName(aiChoice)}，Draw！重新选择。`;
       rpsChoices.human = null;
       rpsChoices.player2 = null;
     }

--- a/apps/board-game/tic-tac-toe/game.js
+++ b/apps/board-game/tic-tac-toe/game.js
@@ -299,9 +299,9 @@ if (typeof document !== "undefined") {
     if (state.gameOver) {
       updateMessage("游戏结束！", "info");
     } else if (state.aiThinking) {
-      updateMessage("AI正在思考...", "info");
+      updateMessage("电脑正在思考...", "info");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
-      updateMessage("轮到AI行动", "info");
+      updateMessage("轮到电脑行动", "info");
     } else {
       updateMessage("轮到 " + state.currentPlayer + " 落子", "info");
     }
@@ -644,7 +644,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，你赢了！你先手(X)。";
         setTimeout(() => {
@@ -654,9 +654,9 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
-          "，你输了！AI先手(X)。";
+          "，你输了！电脑先手(X)。";
         setTimeout(() => {
           startGame("pve", PLAYER_O);
         }, 1500);
@@ -664,7 +664,7 @@ if (typeof document !== "undefined") {
         resultEl.textContent =
           "你选择了" +
           getRPSName(choice) +
-          "，AI选择了" +
+          "，电脑选择了" +
           getRPSName(aiChoice) +
           "，平局！重新选择。";
         rpsChoices.human = null;

--- a/apps/childhood-board-game/bai-si-long/game.js
+++ b/apps/childhood-board-game/bai-si-long/game.js
@@ -504,7 +504,7 @@ if (typeof document !== "undefined") {
 
     var msg = document.getElementById("message");
     if (state.aiThinking) {
-      msg.textContent = "AI 思考中…";
+      msg.textContent = "电脑思考中…";
       msg.className = "info";
     } else {
       msg.textContent = "";
@@ -656,12 +656,12 @@ if (typeof document !== "undefined") {
     var resultDiv = document.getElementById("rps-result");
     if (result === 1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
       // Player wins RPS -> human (B) goes first.
       setTimeout(() => startGame("pve", PLAYER_B), 1200);
     } else if (result === -1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
       // AI wins RPS -> AI (A) goes first.
       setTimeout(() => startGame("pve", PLAYER_A), 1200);
     } else {

--- a/apps/childhood-board-game/bai-si-long/index.html
+++ b/apps/childhood-board-game/bai-si-long/index.html
@@ -189,8 +189,8 @@
         <div id="rule-pve" class="rule-section">
           <h4>🤖 人机模式</h4>
           <ul>
-            <li>玩家执下方 (B)，AI 执上方 (A)</li>
-            <li>AI 会主动连子并阻断你的成龙路线</li>
+            <li>玩家执下方 (B)，电脑执上方 (A)</li>
+            <li>电脑会主动连子并阻断你的成龙路线</li>
           </ul>
         </div>
       </div>

--- a/apps/childhood-board-game/bie-mao-keng/game.js
+++ b/apps/childhood-board-game/bie-mao-keng/game.js
@@ -749,14 +749,14 @@ if (typeof document !== "undefined") {
       if (result === 1) {
         // Player wins RPS, player goes first (player is B in PvE)
         resultDiv.innerHTML =
-          "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+          "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
         setTimeout(() => {
           startGame("pve", PLAYER_B);
         }, 1500);
       } else if (result === -1) {
         // AI wins RPS, AI goes first (AI is A in PvE)
         resultDiv.innerHTML =
-          "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+          "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
         setTimeout(() => {
           startGame("pve", PLAYER_A);
         }, 1500);

--- a/apps/childhood-board-game/lang-chi-yang/game.js
+++ b/apps/childhood-board-game/lang-chi-yang/game.js
@@ -627,13 +627,13 @@ if (typeof document !== "undefined") {
       var resultDiv = document.getElementById("rps-result");
       if (result === 1) {
         resultDiv.innerHTML =
-          "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+          "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
         setTimeout(() => {
           startGame("pve", PLAYER_A);
         }, 1500);
       } else if (result === -1) {
         resultDiv.innerHTML =
-          "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+          "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
         setTimeout(() => {
           startGame("pve", PLAYER_B);
         }, 1500);

--- a/apps/childhood-board-game/ma-yi-ban-jia/game.js
+++ b/apps/childhood-board-game/ma-yi-ban-jia/game.js
@@ -530,7 +530,7 @@ if (typeof document !== "undefined") {
 
     var msg = document.getElementById("message");
     if (state.aiThinking) {
-      msg.textContent = "AI 思考中…";
+      msg.textContent = "电脑思考中…";
       msg.className = "info";
     } else {
       msg.textContent = "";
@@ -890,12 +890,12 @@ if (typeof document !== "undefined") {
     var resultDiv = document.getElementById("rps-result");
     if (result === 1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
       // Player wins RPS -> human (B) goes first.
       setTimeout(() => startGame("pve", PLAYER_B), 1200);
     } else if (result === -1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
       // AI wins RPS -> AI (A) goes first.
       setTimeout(() => startGame("pve", PLAYER_A), 1200);
     } else {

--- a/apps/childhood-board-game/ma-yi-ban-jia/index.html
+++ b/apps/childhood-board-game/ma-yi-ban-jia/index.html
@@ -191,8 +191,8 @@
         <div id="rule-pve" class="rule-section">
           <h4>🤖 人机模式</h4>
           <ul>
-            <li>玩家执下方 (B)，AI 执上方 (A)</li>
-            <li>AI 会主动北上（南下）入家并阻挡你的搬迁路线</li>
+            <li>玩家执下方 (B)，电脑执上方 (A)</li>
+            <li>电脑会主动北上（南下）入家并阻挡你的搬迁路线</li>
           </ul>
         </div>
       </div>

--- a/apps/childhood-board-game/si-bu-ding/game.js
+++ b/apps/childhood-board-game/si-bu-ding/game.js
@@ -518,7 +518,7 @@ if (typeof document !== "undefined") {
 
     var msg = document.getElementById("message");
     if (state.aiThinking) {
-      msg.textContent = "AI 思考中…";
+      msg.textContent = "电脑思考中…";
       msg.className = "info";
     } else if (state.lastCaptures && state.lastCaptures.length > 0) {
       msg.textContent = "吃掉对方 " + state.lastCaptures.length + " 子！";
@@ -865,12 +865,12 @@ if (typeof document !== "undefined") {
     var resultDiv = document.getElementById("rps-result");
     if (result === 1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
       // Player wins RPS -> human (B) goes first.
       setTimeout(() => startGame("pve", PLAYER_B), 1200);
     } else if (result === -1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
       // AI wins RPS -> AI (A) goes first.
       setTimeout(() => startGame("pve", PLAYER_A), 1200);
     } else {

--- a/apps/childhood-board-game/si-bu-ding/index.html
+++ b/apps/childhood-board-game/si-bu-ding/index.html
@@ -196,8 +196,8 @@
         <div id="rule-pve" class="rule-section">
           <h4>🤖 人机模式</h4>
           <ul>
-            <li>玩家执下方 (B)，AI 执上方 (A)</li>
-            <li>AI 会主动制造夹击并阻断你的吃子机会</li>
+            <li>玩家执下方 (B)，电脑执上方 (A)</li>
+            <li>电脑会主动制造夹击并阻断你的吃子机会</li>
           </ul>
         </div>
       </div>

--- a/apps/childhood-board-game/xiao-mao-diao-yu/game.js
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/game.js
@@ -526,7 +526,7 @@ if (typeof document !== "undefined") {
     }
 
     if (state.aiThinking) {
-      document.getElementById("message").textContent = "AI 思考中…";
+      document.getElementById("message").textContent = "电脑思考中…";
       document.getElementById("message").className = "info";
     } else {
       document.getElementById("message").textContent = "";
@@ -658,11 +658,11 @@ if (typeof document !== "undefined") {
     var resultDiv = document.getElementById("rps-result");
     if (result === 1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
       setTimeout(() => startGame("pve", PLAYER_A), 1200);
     } else if (result === -1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
       setTimeout(() => startGame("pve", PLAYER_B), 1200);
     } else {
       resultDiv.innerHTML = "<p>平局！再来一次</p>";

--- a/apps/childhood-board-game/xiao-mao-diao-yu/index.html
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/index.html
@@ -211,8 +211,8 @@
         <div id="rule-pve" class="rule-section">
           <h4>🤖 人机模式</h4>
           <ul>
-            <li>你执猫，AI 执鱼</li>
-            <li>AI 会优先吃子并保留机动性</li>
+            <li>你执猫，电脑执鱼</li>
+            <li>电脑会优先吃子并保留机动性</li>
           </ul>
         </div>
       </div>

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/game.js
@@ -547,7 +547,7 @@ if (typeof document !== "undefined") {
     document.getElementById("moves-b").textContent = getValidMoves(state.board, PLAYER_B).length;
 
     if (state.aiThinking) {
-      document.getElementById("message").textContent = "AI 思考中…";
+      document.getElementById("message").textContent = "电脑思考中…";
       document.getElementById("message").className = "info";
     } else {
       document.getElementById("message").textContent = "";
@@ -865,11 +865,11 @@ if (typeof document !== "undefined") {
     var resultDiv = document.getElementById("rps-result");
     if (result === 1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，你先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，你先手！</p>";
       setTimeout(() => startGame("pve", PLAYER_A), 1200);
     } else if (result === -1) {
       resultDiv.innerHTML =
-        "<p>你出" + getRPSName(choice) + "，AI出" + getRPSName(aiChoice) + "，AI先手！</p>";
+        "<p>你出" + getRPSName(choice) + "，电脑出" + getRPSName(aiChoice) + "，电脑先手！</p>";
       setTimeout(() => startGame("pve", PLAYER_B), 1200);
     } else {
       resultDiv.innerHTML = "<p>平局！再来一次</p>";

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/index.html
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/index.html
@@ -190,8 +190,8 @@
         <div id="rule-pve" class="rule-section">
           <h4>🤖 人机模式</h4>
           <ul>
-            <li>你执追兵，AI 执逃兵</li>
-            <li>AI 会朝牛角根方向逃窜并尽量保持机动性</li>
+            <li>你执追兵，电脑执逃兵</li>
+            <li>电脑会朝牛角根方向逃窜并尽量保持机动性</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Changed all displayed "AI" text to "电脑" for consistency in PvE mode across all games.

### Changes

**HTML files (game instructions):**
- 钻牛角尖、小猫钓鱼、四不定、摆四龙、蚂蚁搬家

**JS files (in-game messages):**
- Thinking messages: "AI思考中…" → "电脑思考中…"
- Turn indicators: "轮到AI行动" → "轮到电脑行动"
- RPS first-move messages: "AI出/先手" → "电脑出/先手"

Affected games: 9 board-games + 7 childhood-board-games = 16 games total.

### Intentionally unchanged

Code-level identifiers (variable names like `aiTeam`, `aiThinking`, function names like `triggerAI()`, `getBestAIMove()`, and algorithm comments) are left unchanged — they describe AI logic, not user-facing labels.

### Verification

- ✅ All 1652 tests pass
- ✅ Lint passes (no new warnings)
- ✅ 21 files changed, 80 insertions, 80 deletions

Fixes #37