### PR TITLE
fix(lang-chi-yang): convert board from CSS grid cells to SVG intersection nodes

### DIFF
--- a/apps/childhood-board-game/lang-chi-yang/game.css
+++ b/apps/childhood-board-game/lang-chi-yang/game.css
@@ -1,11 +1,9 @@
 :root {
   --a-color: #1565c0;
   --b-color: #e53935;
-  --board-bg: #5d4037;
-  --cell-bg: rgba(255, 255, 255, 0.95);
-  --cell-border: #bdbdbd;
-  --cell-size: 100px;
-  --cell-gap: 2px;
+  --board-bg: #f9f3e3;
+  --board-line: #2c2c2c;
+  --node-empty: #ffffff;
   --overlay-bg: rgba(0, 0, 0, 0.5);
 }
 
@@ -154,63 +152,98 @@ body {
 }
 
 #board {
-  display: grid;
-  grid-template-columns: repeat(4, var(--cell-size));
-  grid-template-rows: repeat(5, var(--cell-size));
-  gap: var(--cell-gap);
   background: var(--board-bg);
-  padding: 8px;
+  padding: 16px;
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  width: min(560px, 95vw);
 }
-.cell {
-  background: var(--cell-bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 36px;
-  font-weight: bold;
+.board-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.board-line {
+  stroke: var(--board-line);
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+
+.node {
   cursor: pointer;
-  border-radius: 8px;
-  transition: all 0.15s;
+}
+.node-hit {
+  fill: transparent;
+}
+.node-circle {
+  fill: var(--node-empty);
+  stroke: var(--board-line);
+  stroke-width: 2;
+  transition:
+    fill 0.15s,
+    stroke 0.15s,
+    opacity 0.15s;
+}
+.node-empty .node-circle {
+  fill: transparent;
+  stroke: transparent;
+  opacity: 0;
+  pointer-events: none;
+}
+.node-dot {
+  fill: var(--board-line);
+  pointer-events: none;
+}
+.node-a .node-dot,
+.node-b .node-dot,
+.node-empty.node-highlight .node-dot {
+  display: none;
+}
+.node-text {
+  font-size: 18px;
+  font-weight: bold;
+  fill: #fff;
+  pointer-events: none;
   user-select: none;
 }
-.cell:hover {
-  transform: scale(1.05);
-  z-index: 1;
+.node-a .node-circle {
+  fill: var(--a-color);
+  stroke: #0d3c6e;
+  opacity: 1;
 }
-.cell-a {
-  color: var(--a-color);
-  text-shadow: 0 2px 4px rgba(21, 101, 192, 0.3);
+.node-b .node-circle {
+  fill: var(--b-color);
+  stroke: #8b1a17;
+  opacity: 1;
 }
-.cell-b {
-  color: var(--b-color);
-  text-shadow: 0 2px 4px rgba(229, 57, 53, 0.3);
+
+.node-selected .node-circle {
+  stroke: #ff9800;
+  stroke-width: 5;
+  filter: drop-shadow(0 0 6px rgba(255, 152, 0, 0.85));
 }
-.cell-selected {
-  outline: 3px solid #ff9800;
-  background: #fff3e0;
+.node-empty.node-highlight .node-circle {
+  fill: #fff59d;
+  stroke: #f9a825;
+  stroke-width: 3;
+  opacity: 1;
+  pointer-events: auto;
 }
-.cell-highlight {
-  background: #e8f5e9;
+.node-captured .node-circle {
+  opacity: 0.4;
 }
-.cell-jump {
-  background: #fce4ec;
-}
-.cell-captured {
-  background: #ffcdd2;
-  opacity: 0.5;
-}
-.cell-win {
-  background: #fff9c4;
+.node-win .node-circle {
+  stroke: #ffd600;
+  stroke-width: 5;
   animation: winPulse 0.8s ease-in-out infinite alternate;
 }
 @keyframes winPulse {
   from {
-    box-shadow: 0 0 8px #ffd600;
+    filter: drop-shadow(0 0 4px rgba(255, 214, 0, 0.6));
   }
   to {
-    box-shadow: 0 0 20px #ffd600;
+    filter: drop-shadow(0 0 14px rgba(255, 214, 0, 1));
   }
 }
 
@@ -275,9 +308,6 @@ body {
 }
 
 @media (max-width: 700px) {
-  :root {
-    --cell-size: calc((100vw - 80px) / 4);
-  }
   .overlay-content {
     padding: 24px;
     margin: 16px;

--- a/apps/childhood-board-game/lang-chi-yang/game.js
+++ b/apps/childhood-board-game/lang-chi-yang/game.js
@@ -19,6 +19,13 @@ var INITIAL_A = 10; // Sheep starts with 10 pieces
 var INITIAL_B = 2; // Wolf starts with 2 pieces
 var MIN_A_TO_LOSE = 3; // If sheep has fewer than 3 pieces, wolf wins
 
+// SVG board rendering constants
+var BOARD_PADDING = 40;
+var CELL_SIZE = 100;
+var BOARD_VIEW_W = BOARD_PADDING * 2 + (COL_COUNT - 1) * CELL_SIZE;
+var BOARD_VIEW_H = BOARD_PADDING * 2 + (ROW_COUNT - 1) * CELL_SIZE;
+var svgNS = "http://www.w3.org/2000/svg";
+
 var DIRECTIONS = [
   { dr: -1, dc: 0 },
   { dr: 1, dc: 0 },
@@ -382,68 +389,141 @@ if (typeof document !== "undefined") {
   var localTeam = null;
   var remoteTeam = null;
 
+  function nodeToPx(x, y) {
+    return {
+      cx: BOARD_PADDING + x * CELL_SIZE,
+      cy: BOARD_PADDING + y * CELL_SIZE,
+    };
+  }
+
   function initBoard() {
     var boardEl = document.getElementById("board");
     boardEl.innerHTML = "";
+    var svg = document.createElementNS(svgNS, "svg");
+    svg.setAttribute("viewBox", "0 0 " + BOARD_VIEW_W + " " + BOARD_VIEW_H);
+    svg.setAttribute("class", "board-svg");
+
+    // Draw horizontal lines (one per row)
     for (var r = 0; r < ROW_COUNT; r++) {
-      for (var c = 0; c < COL_COUNT; c++) {
-        var cell = document.createElement("div");
-        cell.className = "cell";
-        cell.dataset.r = r;
-        cell.dataset.c = c;
-        cell.addEventListener(
+      var p0 = nodeToPx(0, r);
+      var p1 = nodeToPx(COL_COUNT - 1, r);
+      var hLine = document.createElementNS(svgNS, "line");
+      hLine.setAttribute("x1", p0.cx);
+      hLine.setAttribute("y1", p0.cy);
+      hLine.setAttribute("x2", p1.cx);
+      hLine.setAttribute("y2", p1.cy);
+      hLine.setAttribute("class", "board-line");
+      svg.appendChild(hLine);
+    }
+
+    // Draw vertical lines (one per column)
+    for (var c = 0; c < COL_COUNT; c++) {
+      var q0 = nodeToPx(c, 0);
+      var q1 = nodeToPx(c, ROW_COUNT - 1);
+      var vLine = document.createElementNS(svgNS, "line");
+      vLine.setAttribute("x1", q0.cx);
+      vLine.setAttribute("y1", q0.cy);
+      vLine.setAttribute("x2", q1.cx);
+      vLine.setAttribute("y2", q1.cy);
+      vLine.setAttribute("class", "board-line");
+      svg.appendChild(vLine);
+    }
+
+    // Interactive intersection nodes
+    for (var y = 0; y < ROW_COUNT; y++) {
+      for (var x = 0; x < COL_COUNT; x++) {
+        var pt = nodeToPx(x, y);
+        var g = document.createElementNS(svgNS, "g");
+        g.setAttribute("class", "node");
+        g.dataset.x = x;
+        g.dataset.y = y;
+        g.setAttribute("transform", "translate(" + pt.cx + "," + pt.cy + ")");
+
+        // Wide invisible hit area for easier tapping
+        var hit = document.createElementNS(svgNS, "circle");
+        hit.setAttribute("r", CELL_SIZE / 2 - 2);
+        hit.setAttribute("class", "node-hit");
+        g.appendChild(hit);
+
+        // Small dot showing the intersection when no piece is placed
+        var dot = document.createElementNS(svgNS, "circle");
+        dot.setAttribute("r", 4);
+        dot.setAttribute("class", "node-dot");
+        g.appendChild(dot);
+
+        // Piece circle (hidden when empty)
+        var circle = document.createElementNS(svgNS, "circle");
+        circle.setAttribute("r", 22);
+        circle.setAttribute("class", "node-circle");
+        g.appendChild(circle);
+
+        // Text label for the piece
+        var text = document.createElementNS(svgNS, "text");
+        text.setAttribute("class", "node-text");
+        text.setAttribute("text-anchor", "middle");
+        text.setAttribute("dominant-baseline", "central");
+        g.appendChild(text);
+
+        g.addEventListener(
           "click",
-          (function (cr, cc) {
+          (function (cx, cy) {
             return function () {
-              handleCellClick(cr, cc);
+              handlePositionClick(cx, cy);
             };
-          })(r, c)
+          })(x, y)
         );
-        boardEl.appendChild(cell);
+        svg.appendChild(g);
       }
     }
+
+    boardEl.appendChild(svg);
   }
 
   function renderGame() {
     if (!state) return;
-    var cells = document.querySelectorAll("#board .cell");
-    cells.forEach((cell) => {
-      var r = Number.parseInt(cell.dataset.r);
-      var c = Number.parseInt(cell.dataset.c);
-      cell.textContent = "";
-      cell.className = "cell";
-      if (state.board[r][c] === PLAYER_A) {
-        cell.classList.add("cell-a");
-        cell.textContent = "羊";
-      } else if (state.board[r][c] === PLAYER_B) {
-        cell.classList.add("cell-b");
-        cell.textContent = "狼";
+    var nodes = document.querySelectorAll("#board .node");
+    nodes.forEach((g) => {
+      var nx = Number.parseInt(g.dataset.x);
+      var ny = Number.parseInt(g.dataset.y);
+      var classes = ["node"];
+      var label = "";
+      if (state.board[ny][nx] === PLAYER_A) {
+        classes.push("node-a");
+        label = "羊";
+      } else if (state.board[ny][nx] === PLAYER_B) {
+        classes.push("node-b");
+        label = "狼";
+      } else {
+        classes.push("node-empty");
       }
-      if (selectedPiece && selectedPiece.r === r && selectedPiece.c === c) {
-        cell.classList.add("cell-selected");
+      if (selectedPiece && selectedPiece.r === ny && selectedPiece.c === nx) {
+        classes.push("node-selected");
       }
       if (selectedPiece) {
         // Highlight step moves
         var stepMoves = getStepMoves(state.board, selectedPiece.r, selectedPiece.c);
         for (var i = 0; i < stepMoves.length; i++) {
-          if (stepMoves[i].toR === r && stepMoves[i].toC === c) {
-            cell.classList.add("cell-highlight");
+          if (stepMoves[i].toR === ny && stepMoves[i].toC === nx) {
+            classes.push("node-highlight");
           }
         }
         // Highlight jump moves for wolf
         if (state.currentPlayer === PLAYER_B) {
           var jumpMoves = getJumpMoves(state.board, selectedPiece.r, selectedPiece.c);
           for (var j = 0; j < jumpMoves.length; j++) {
-            if (jumpMoves[j].toR === r && jumpMoves[j].toC === c) {
-              cell.classList.add("cell-jump");
+            if (jumpMoves[j].toR === ny && jumpMoves[j].toC === nx) {
+              classes.push("node-highlight");
             }
           }
         }
       }
       // Highlight last jump capture
-      if (state.lastJump && state.lastJump.captureR === r && state.lastJump.captureC === c) {
-        cell.classList.add("cell-captured");
+      if (state.lastJump && state.lastJump.captureR === ny && state.lastJump.captureC === nx) {
+        classes.push("node-captured");
       }
+      g.setAttribute("class", classes.join(" "));
+      var text = g.querySelector(".node-text");
+      if (text) text.textContent = label;
     });
 
     // Current acting side - shown as 玩家/电脑 (PVE), 玩家1/玩家2 (PVP), or 你/对方 (online)
@@ -488,10 +568,14 @@ if (typeof document !== "undefined") {
     }
   }
 
-  function handleCellClick(r, c) {
+  function handlePositionClick(x, y) {
     if (!state || state.gameOver) return;
     if (state.mode === "online" && state.currentPlayer !== localTeam) return;
     if (state.mode === "pve" && state.currentPlayer === state.aiTeam) return;
+
+    // SVG (x, y) maps to board (r=y, c=x)
+    var r = y;
+    var c = x;
 
     // Select own piece
     if (state.board[r][c] === state.currentPlayer) {
@@ -549,7 +633,7 @@ if (typeof document !== "undefined") {
         }
       }
 
-      // Clicked on invalid cell, deselect
+      // Clicked on invalid position, deselect
       selectedPiece = null;
       renderGame();
     }


### PR DESCRIPTION
## Issue

Closes #36

## Problem

狼吃羊游戏使用 CSS Grid 格子放棋子，与其它童年经典棋盘游戏（四步钉、摆四龙、憋茅坑等）在交点放棋子的风格不一致。

| 方面 | 修改前（格子风格） | 修改后（交点风格） |
|------|-------------------|-------------------|
| 渲染技术 | CSS Grid `<div>` | SVG 交点节点 |
| 棋盘背景 | 深棕色 `#5d4037` | 浅木色 `#f9f3e3` |
| 棋子放置 | 白色方块内文字（羊/狼） | 彩色圆点在交点上（蓝=羊，红=狼） |
| 网格线 | 隐式（格子间隙） | 显式 SVG `<line>` |

## Solution

- `initBoard()`: 用 SVG 替代 CSS Grid，绘制网格线和交点节点（hit area + dot + circle + text）
- `renderGame()`: 使用 SVG class（`node-a`/`node-b`/`node-empty`）替代 `textContent`
- `handleCellClick` → `handlePositionClick(x, y)`: 坐标系适配
- CSS: 删除所有 `.cell*` 样式，添加 `.board-svg`、`.board-line`、`.node*` SVG 样式
- 使用矩形 viewBox (380×480) 确保 4×5 棋盘居中显示

## Verification

- ✅ 1652 个测试全部通过
- ✅ lint 无新增问题
- ✅ 棋盘居中显示，风格与其它游戏一致