### PR TITLE
fix: unify board game mode selection UI to match card game style (#35)

### DIFF
--- a/apps/childhood-board-game/bai-si-long/game.css
+++ b/apps/childhood-board-game/bai-si-long/game.css
@@ -29,8 +29,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -91,20 +90,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -305,11 +307,14 @@ body {
 
 @media (max-width: 700px) {
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   #rules-panel {
     max-width: 100%;

--- a/apps/childhood-board-game/bie-mao-keng/game.css
+++ b/apps/childhood-board-game/bie-mao-keng/game.css
@@ -30,8 +30,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -92,20 +91,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -279,11 +281,14 @@ body {
 
 @media (max-width: 700px) {
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   #rules-panel {
     max-width: 100%;

--- a/apps/childhood-board-game/lang-chi-yang/game.css
+++ b/apps/childhood-board-game/lang-chi-yang/game.css
@@ -31,8 +31,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -93,20 +92,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -279,11 +281,14 @@ body {
     --cell-size: calc((100vw - 80px) / 4);
   }
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   #rules-panel {
     max-width: 100%;

--- a/apps/childhood-board-game/ma-yi-ban-jia/game.css
+++ b/apps/childhood-board-game/ma-yi-ban-jia/game.css
@@ -29,8 +29,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -91,20 +90,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -321,11 +323,14 @@ body {
 
 @media (max-width: 700px) {
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   #rules-panel {
     max-width: 100%;

--- a/apps/childhood-board-game/si-bu-ding/game.css
+++ b/apps/childhood-board-game/si-bu-ding/game.css
@@ -29,8 +29,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -91,20 +90,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -278,11 +280,14 @@ body {
 
 @media (max-width: 700px) {
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   #rules-panel {
     max-width: 100%;

--- a/apps/childhood-board-game/xiao-mao-diao-yu/game.css
+++ b/apps/childhood-board-game/xiao-mao-diao-yu/game.css
@@ -29,8 +29,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -91,20 +90,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -328,11 +330,14 @@ body {
 
 @media (max-width: 700px) {
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   .board-svg {
     width: 90vw;

--- a/apps/childhood-board-game/zuan-niu-jiao-jian/game.css
+++ b/apps/childhood-board-game/zuan-niu-jiao-jian/game.css
@@ -29,8 +29,7 @@ body {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  font-weight: bold;
+  transition: transform 0.15s, box-shadow 0.15s;
 }
 .btn:hover {
   transform: translateY(-2px);
@@ -91,20 +90,23 @@ body {
   padding: 40px 48px;
   text-align: center;
   max-width: 500px;
+  width: 90%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 .game-title {
-  font-size: 2.5em;
-  margin-bottom: 8px;
+  font-size: 42px;
+  margin-bottom: 4px;
 }
 .subtitle {
-  color: #757575;
-  margin-bottom: 24px;
+  font-size: 16px;
+  color: #888;
+  margin-bottom: 32px;
 }
 .mode-buttons {
   display: flex;
-  flex-direction: column;
   gap: 12px;
-  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: center;
 }
 
 #game-area {
@@ -286,11 +288,14 @@ body {
 
 @media (max-width: 700px) {
   .overlay-content {
-    padding: 24px;
-    margin: 16px;
+    padding: 28px 20px;
   }
   .game-title {
-    font-size: 1.8em;
+    font-size: 32px;
+  }
+  .mode-buttons {
+    flex-direction: column;
+    gap: 12px;
   }
   #rules-panel {
     max-width: 100%;


### PR DESCRIPTION
## Summary

Closes #35.

Unify the mode selection interface styling of all 7 childhood board games to match the newer card game pattern, ensuring a consistent visual experience across all game categories.

## Problem

The 7 games in `apps/childhood-board-game/` used an older CSS pattern for their mode selection screen (the overlay with game title, subtitle, and three mode buttons). Compared to the card games and standard board games, they had:

- **Vertical button layout** (`flex-direction: column`) instead of horizontal side-by-side buttons
- **Missing responsive width** (`width: 90%`) on the overlay content
- **Missing box-shadow** on the overlay content card
- **Different font sizes and spacing** for title and subtitle
- **Inconsistent button transitions** (`transition: all 0.2s` vs `transform 0.15s, box-shadow 0.15s`)

## Solution

Updated all 7 `game.css` files in `apps/childhood-board-game/` to match the newer CSS pattern used by `apps/card-game/` and `apps/board-game/`:

- `.overlay-content`: added `width: 90%` and `box-shadow: 0 8px 32px rgba(0,0,0,0.3)`
- `.game-title`: changed to `font-size: 42px`, `margin-bottom: 4px`
- `.subtitle`: changed to `font-size: 16px`, `color: #888`, `margin-bottom: 32px`
- `.mode-buttons`: changed to horizontal layout (`flex-wrap: nowrap`, `justify-content: center`)
- `.btn`: updated transition to `transform 0.15s, box-shadow 0.15s`, removed `font-weight: bold`
- Added mobile responsive stacking (`flex-direction: column`) at `max-width: 700px`

## Changes
- `apps/childhood-board-game/bai-si-long/game.css` — mode selection CSS update
- `apps/childhood-board-game/bie-mao-keng/game.css` — mode selection CSS update
- `apps/childhood-board-game/lang-chi-yang/game.css` — mode selection CSS update
- `apps/childhood-board-game/ma-yi-ban-jia/game.css` — mode selection CSS update
- `apps/childhood-board-game/si-bu-ding/game.css` — mode selection CSS update
- `apps/childhood-board-game/xiao-mao-diao-yu/game.css` — mode selection CSS update
- `apps/childhood-board-game/zuan-niu-jiao-jian/game.css` — mode selection CSS update

## Verification
- `npm run lint` ✓ (0 errors)
- `npm test` ✓ (1656 tests passed)

## Notes for reviewer
- The changes are purely CSS — no HTML or JS was modified
- Only mode selection / overlay styling was changed; game board styles remain untouched
- Mobile responsive behavior now matches the card game pattern (horizontal on desktop, vertical on mobile)
