### PR TITLE
fix: correct move property names and PVE first-player logic (#47)

### DIFF
--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -1043,7 +1043,7 @@ if (typeof document !== "undefined") {
 
   function doMove(move) {
     // Play sound based on move type
-    const targetPiece = gameState.board[move.toRow][move.toCol];
+    const targetPiece = gameState.board[move.toR][move.toC];
     if (targetPiece !== EMPTY) {
       SoundManager.play("take");
     } else {
@@ -1087,7 +1087,7 @@ if (typeof document !== "undefined") {
       gameState.aiThinking = false;
       if (move) {
         // Play sound based on move type
-        const targetPiece = gameState.board[move.toRow][move.toCol];
+        const targetPiece = gameState.board[move.toR][move.toC];
         if (targetPiece !== EMPTY) {
           SoundManager.play("take");
         } else {

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -1101,20 +1101,16 @@ if (typeof document !== "undefined") {
     }, 300);
   }
 
-  function startGame(mode, firstPlayer) {
+  function startGame(mode, playerTeam) {
     gameState = createGameState(mode);
-    gameState.currentPlayer = firstPlayer || RED;
-    gameState.firstPlayer = firstPlayer || RED;
+    // In Chinese Chess, RED always moves first
+    gameState.currentPlayer = RED;
+    gameState.firstPlayer = RED;
     gameState.boardFlipped = false;
 
     if (mode === "pve") {
-      if (firstPlayer === RED) {
-        gameState.playerTeam = RED;
-        gameState.aiTeam = BLACK;
-      } else {
-        gameState.playerTeam = BLACK;
-        gameState.aiTeam = RED;
-      }
+      gameState.playerTeam = playerTeam || RED;
+      gameState.aiTeam = playerTeam === RED ? BLACK : RED;
       gameState.boardFlipped = gameState.playerTeam === BLACK;
     }
 


### PR DESCRIPTION
## Summary

Closes #47.

Fix two bugs in the Chinese Chess game: (1) a TypeError that crashes every move attempt due to incorrect property names, and (2) the first-player logic in PVE mode that incorrectly lets the loser go first.

## Problem

**Bug 1 — TypeError on every move:** In `doMove()` and `triggerAI()`, the code accesses `move.toRow` and `move.toCol`, but the move object uses `toC` and `toR`. This causes a `TypeError: Cannot read properties of undefined` on every move, preventing the board from updating and the turn from advancing — the game appears "stuck".

**Bug 2 — Wrong first player after RPS loss:** When the human loses the rock-paper-scissors in PVE mode, `startGame("pve", BLACK)` is called, which sets `gameState.currentPlayer = BLACK`. In Chinese Chess, RED always moves first. The fix ensures RED always goes first, and the `playerTeam` parameter only determines which side the human plays.

## Solution

1. **Fix move property names:** Changed `move.toRow` → `move.toR` and `move.toCol` → `move.toC` in both `doMove()` (line 1046) and `triggerAI()` (line 1090).

2. **Fix first-player logic:** Renamed the `firstPlayer` parameter to `playerTeam` in `startGame()` and hardcoded `gameState.currentPlayer = RED` (since RED always moves first in Chinese Chess). The parameter now only controls which team the human plays on.

## Changes
- `apps/board-game/chinese-chess/game.js` — Fixed `move.toRow`/`move.toCol` → `move.toR`/`move.toC` in `doMove()` and `triggerAI()`; fixed `startGame()` to always start with RED and use the parameter for player team assignment only.

## Verification
- `npm run lint` ✓
- `npm test` ✓ (1656 tests passed)

## Notes for reviewer
- The `startGame()` parameter rename from `firstPlayer` to `playerTeam` is safe — in PVP mode the parameter is unused (playerTeam stays null from createGameState).
