### PR TITLE
fix: correct SoundManager base path for flying chess (#50)

### DIFF
--- a/apps/dice-game/flying-chess/game.js
+++ b/apps/dice-game/flying-chess/game.js
@@ -382,7 +382,7 @@ if (typeof $j !== "undefined") {
 
   // ---- Audio ----
   // Use shared SoundManager for audio playback
-  SoundManager.init("../../../audio");
+  SoundManager.init("../../audio");
 
   // ---- Option ----
   function PLANEUSER(color, state) {


### PR DESCRIPTION
## Summary

Closes #50.

Fixed the incorrect base path for `SoundManager` in flying chess game, which caused audio files to fail loading after PR #46 migration.

## Problem

After PR #46 migrated flying chess from the custom `PlaneAudio` system to the shared `SoundManager`, the sound effects stopped working. The root cause was an incorrect relative path in `SoundManager.init()`.

## Solution

The `SoundManager.init("../../../audio")` call in `game.js` used one too many `../` levels. Since:
- `index.html` is at `apps/dice-game/flying-chess/index.html`
- Audio files are at `apps/audio/`

The correct relative path from the HTML file to the audio directory is `../../audio`, not `../../../audio`.

## Changes
- `apps/dice-game/flying-chess/game.js` — Fixed `SoundManager.init()` path from `"../../../audio"` to `"../../audio"`

## Verification
- `npm run lint` ✓ (0 errors, 41 warnings — all pre-existing)
- `npm test` ✓ (1656 tests passed)
- CI: `Childhood CI` ✓ · `SonarQube Analysis` ✓ · `CodeQL` ✓

## Notes for reviewer
- This is a one-line fix correcting the relative path depth
- All existing tests pass without modification
