### PR TITLE
fix: ensure correct canvas aspect ratio on all platforms (#49)

### DIFF
--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -697,16 +697,12 @@ if (typeof document !== "undefined") {
 
   function initBoard() {
     canvas = document.getElementById("board-canvas");
-    canvas.width = BOARD_W;
-    canvas.height = BOARD_H;
-    if (window.devicePixelRatio > 1) {
-      canvas.width = BOARD_W * window.devicePixelRatio;
-      canvas.height = BOARD_H * window.devicePixelRatio;
-      canvas.style.width = BOARD_W + "px";
-      canvas.style.height = BOARD_H + "px";
-    }
-    context = canvas.getContext("2d");
     const ratio = window.devicePixelRatio || 1;
+    canvas.width = BOARD_W * ratio;
+    canvas.height = BOARD_H * ratio;
+    canvas.style.width = BOARD_W + "px";
+    canvas.style.height = BOARD_H + "px";
+    context = canvas.getContext("2d");
     context.scale(ratio, ratio);
     drawBoard();
   }


### PR DESCRIPTION
## Summary

Closes #49.

Fix the Chinese chess board aspect ratio issue on GitHub Pages by always setting canvas display dimensions explicitly.

## Problem

The Chinese chess board appeared squished/distorted on GitHub Pages (https://jiangxincode.github.io/childhood/apps/board-game/chinese-chess/), while it displayed correctly on local development and Cloudflare Pages mirror.

The root cause was that `initBoard()` only set `canvas.style.width` and `canvas.style.height` when `window.devicePixelRatio > 1`. On devices with devicePixelRatio = 1 (or when the browser reports it as 1), the canvas relied on CSS `height: auto` to calculate the correct aspect ratio, which didn't work consistently across all browsers and deployment environments.

## Solution

Modified `initBoard()` to always set canvas display dimensions (`canvas.style.width` and `canvas.style.height`) regardless of device pixel ratio. This ensures consistent rendering across all platforms.

## Changes
- `apps/board-game/chinese-chess/game.js` - Simplified `initBoard()` to always set canvas dimensions and devicePixelRatio scaling in a unified way

## Verification
- `npm run lint` ✓
- `npm test` ✓ (1656 tests passed)
- CI: `Childhood CI` ✓ · `SonarQube Analysis` ✓ · `CodeQL` ✓

## Notes for reviewer
- The fix aligns the Chinese chess canvas initialization with the pattern used by other board games in the project (e.g., international chess)
- The change is minimal and focused on the specific issue
