### PR TITLE
fix: add check and checkmate detection with visual prompts (#71)

### DIFF
--- a/apps/board-game/chinese-chess/game.css
+++ b/apps/board-game/chinese-chess/game.css
@@ -289,6 +289,34 @@ body {
   background: rgba(76, 175, 80, 0.2);
 }
 
+#message.check {
+  color: #fff;
+  background: linear-gradient(135deg, #e53935 0%, #c62828 100%);
+  font-size: 20px;
+  font-weight: bold;
+  animation: checkPulse 0.5s ease-in-out 2;
+  box-shadow: 0 4px 15px rgba(229, 57, 53, 0.4);
+}
+
+#message.checkmate {
+  color: #fff;
+  background: linear-gradient(135deg, #ff6f00 0%, #e65100 100%);
+  font-size: 24px;
+  font-weight: bold;
+  animation: checkmatePulse 0.3s ease-in-out 3;
+  box-shadow: 0 4px 20px rgba(255, 111, 0, 0.5);
+}
+
+@keyframes checkPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.02); }
+}
+
+@keyframes checkmatePulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
 /* ---- Game Over ---- */
 #game-over .overlay-content h2 {
   font-size: 28px;

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -339,11 +339,11 @@ function getValidMoves(board, c, r) {
   else if (isCannon(piece)) moves = getCannonMoves(board, c, r, color);
   else if (isPawn(piece)) moves = getPawnMoves(board, c, r, color);
 
-  // General facing rule: illegal if own general faces opponent general after move
+  // Filter out illegal moves: general facing and leaving own general in check
   const validMoves = [];
   for (const move of moves) {
     const newBoard = applyMove(board, move);
-    if (!isGeneralFacing(newBoard, color)) {
+    if (!isGeneralFacing(newBoard, color) && !isInCheck(newBoard, color)) {
       validMoves.push(move);
     }
   }

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -1476,7 +1476,11 @@ if (typeof document !== "undefined") {
     renderGame(gameState);
 
     if (gameState.mode === "pve" && gameState.currentPlayer === gameState.aiTeam) {
-      triggerAI();
+      // Delay AI to let check message display briefly
+      const aiDelay = inCheck ? 1000 : 300;
+      setTimeout(() => {
+        triggerAI();
+      }, aiDelay);
     }
   }
 

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -1312,14 +1312,14 @@ if (typeof document !== "undefined") {
 
     if (state.gameOver) {
       if (state.checkStatus === "checkmate") {
-        updateMessage("绝杀！", "error");
+        updateMessage("绝杀！", "checkmate");
       } else {
         updateMessage("游戏结束！", "info");
       }
     } else if (state.aiThinking) {
       updateMessage("电脑正在思考...", "info");
     } else if (state.checkStatus === "check") {
-      updateMessage(getPlayerName(state.currentPlayer) + "被将军！", "error");
+      updateMessage(getPlayerName(state.currentPlayer) + "被将军！", "check");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
       updateMessage("轮到电脑行动", "info");
     } else {
@@ -1340,7 +1340,11 @@ if (typeof document !== "undefined") {
   function updateMessage(text, type) {
     const el = document.getElementById("message");
     el.textContent = text;
-    if (type === "error") {
+    if (type === "check") {
+      el.className = "check";
+    } else if (type === "checkmate") {
+      el.className = "checkmate";
+    } else if (type === "error") {
       el.className = "error";
     } else if (type === "info") {
       el.className = "info";

--- a/apps/board-game/chinese-chess/game.js
+++ b/apps/board-game/chinese-chess/game.js
@@ -584,6 +584,50 @@ function getAllMoves(board, color) {
 // Win/loss detection
 // ============================================================
 
+// Check if the given color's general is under attack by any opponent piece.
+function isInCheck(board, color) {
+  // Find the general's position
+  let gc = -1,
+    gr = -1;
+  const genPiece = color === RED ? R_GENERAL : B_GENERAL;
+  for (let c = 3; c <= 5; c++) {
+    const minR = color === RED ? 7 : 0;
+    const maxR = color === RED ? 9 : 2;
+    for (let r = minR; r <= maxR; r++) {
+      if (board[c][r] === genPiece) {
+        gc = c;
+        gr = r;
+        break;
+      }
+    }
+    if (gc !== -1) break;
+  }
+  if (gc === -1) return false; // General not found (captured)
+
+  const opponent = getOpponent(color);
+  // Check if any opponent piece can attack the general's position
+  for (let c = 0; c < COLS; c++) {
+    for (let r = 0; r < ROWS; r++) {
+      if (board[c][r] !== EMPTY && getOwner(board[c][r]) === opponent) {
+        const piece = board[c][r];
+        let moves = [];
+        if (isGeneral(piece)) moves = getGeneralMoves(board, c, r, opponent);
+        else if (isAdvisor(piece)) moves = getAdvisorMoves(board, c, r, opponent);
+        else if (isElephant(piece)) moves = getElephantMoves(board, c, r, opponent);
+        else if (isHorse(piece)) moves = getHorseMoves(board, c, r, opponent);
+        else if (isChariot(piece)) moves = getChariotMoves(board, c, r, opponent);
+        else if (isCannon(piece)) moves = getCannonMoves(board, c, r, opponent);
+        else if (isPawn(piece)) moves = getPawnMoves(board, c, r, opponent);
+
+        for (const move of moves) {
+          if (move.toC === gc && move.toR === gr) return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 function checkGameOver(board, nextPlayer) {
   let redGeneral = false,
     blackGeneral = false;
@@ -941,6 +985,7 @@ function createGameState(mode) {
     selectedPiece: null,
     validMoves: [],
     lastMove: null,
+    checkStatus: null, // null | "check" | "checkmate"
   };
 }
 
@@ -992,6 +1037,7 @@ if (typeof module !== "undefined" && module.exports) {
     getCannonMoves: getCannonMoves,
     getPawnMoves: getPawnMoves,
     checkGameOver: checkGameOver,
+    isInCheck: isInCheck,
     evaluateBoard: evaluateBoard,
     alphaBeta: alphaBeta,
     getBestAIMove: getBestAIMove,
@@ -1265,9 +1311,15 @@ if (typeof document !== "undefined") {
     }
 
     if (state.gameOver) {
-      updateMessage("游戏结束！", "info");
+      if (state.checkStatus === "checkmate") {
+        updateMessage("绝杀！", "error");
+      } else {
+        updateMessage("游戏结束！", "info");
+      }
     } else if (state.aiThinking) {
       updateMessage("电脑正在思考...", "info");
+    } else if (state.checkStatus === "check") {
+      updateMessage(getPlayerName(state.currentPlayer) + "被将军！", "error");
     } else if (state.mode === "pve" && state.currentPlayer === state.aiTeam) {
       updateMessage("轮到电脑行动", "info");
     } else {
@@ -1405,10 +1457,13 @@ if (typeof document !== "undefined") {
 
   function endTurn() {
     const nextPlayer = getOpponent(gameState.currentPlayer);
+    const inCheck = isInCheck(gameState.board, nextPlayer);
     const gameOverResult = checkGameOver(gameState.board, nextPlayer);
     if (gameOverResult) {
       gameState.gameOver = true;
       gameState.winner = gameOverResult.winner;
+      // Distinguish checkmate from other game over reasons
+      gameState.checkStatus = gameOverResult.reason === "no_moves" && inCheck ? "checkmate" : null;
       renderGame(gameState);
       setTimeout(() => {
         showGameOver(gameState);
@@ -1417,6 +1472,7 @@ if (typeof document !== "undefined") {
     }
 
     gameState.currentPlayer = nextPlayer;
+    gameState.checkStatus = inCheck ? "check" : null;
     renderGame(gameState);
 
     if (gameState.mode === "pve" && gameState.currentPlayer === gameState.aiTeam) {

--- a/apps/board-game/chinese-chess/game.test.js
+++ b/apps/board-game/chinese-chess/game.test.js
@@ -40,6 +40,7 @@ import {
   getCannonMoves,
   getPawnMoves,
   checkGameOver,
+  isInCheck,
   evaluateBoard,
   getBestAIMove,
   createGameState,
@@ -494,6 +495,70 @@ describe("checkGameOver", () => {
     var result = checkGameOver(board, BLACK);
     expect(result).not.toBeNull();
     expect(result.winner).toBe(RED);
+  });
+});
+
+describe("isInCheck", () => {
+  it("returns false for initial board", () => {
+    var board = createBoard();
+    expect(isInCheck(board, RED)).toBe(false);
+    expect(isInCheck(board, BLACK)).toBe(false);
+  });
+  it("detects check by chariot", () => {
+    // Red general at (4,8), black chariot directly below at (4,9)
+    var board = [];
+    for (var c = 0; c < COLS; c++) board.push(new Array(ROWS).fill(EMPTY));
+    board[4][8] = R_GENERAL;
+    board[4][0] = B_GENERAL;
+    board[4][9] = B_CHARIOT; // attacks R_GENERAL vertically
+    expect(isInCheck(board, RED)).toBe(true);
+  });
+  it("detects check by cannon", () => {
+    // Red general at (4,8), black cannon at (4,0) with platform at (4,4)
+    var board = [];
+    for (var c = 0; c < COLS; c++) board.push(new Array(ROWS).fill(EMPTY));
+    board[4][8] = R_GENERAL;
+    board[4][0] = B_GENERAL;
+    board[4][0] = B_CANNON; // override B_GENERAL position for test
+    board[4][4] = B_PAWN; // cannon platform
+    board[3][0] = B_GENERAL; // put black general elsewhere
+    expect(isInCheck(board, RED)).toBe(true);
+  });
+  it("detects check by horse", () => {
+    // Red general at (4,8), black horse at (3,6) can attack (4,8)
+    var board = [];
+    for (var c = 0; c < COLS; c++) board.push(new Array(ROWS).fill(EMPTY));
+    board[4][8] = R_GENERAL;
+    board[4][0] = B_GENERAL;
+    board[3][6] = B_HORSE; // can attack (4,8) via (dx=1, dy=2)
+    expect(isInCheck(board, RED)).toBe(true);
+  });
+  it("detects check by pawn", () => {
+    // Red general at (4,8), black pawn at (4,7) can attack forward
+    var board = [];
+    for (var c = 0; c < COLS; c++) board.push(new Array(ROWS).fill(EMPTY));
+    board[4][8] = R_GENERAL;
+    board[4][0] = B_GENERAL;
+    board[4][7] = B_PAWN; // can attack (4,8) forward
+    expect(isInCheck(board, RED)).toBe(true);
+  });
+  it("returns false when blocked", () => {
+    // Red general at (4,8), black chariot at (4,0) blocked by piece at (4,4)
+    var board = [];
+    for (var c = 0; c < COLS; c++) board.push(new Array(ROWS).fill(EMPTY));
+    board[4][8] = R_GENERAL;
+    board[4][0] = B_CHARIOT;
+    board[4][4] = R_PAWN; // blocks the attack
+    board[3][0] = B_GENERAL;
+    expect(isInCheck(board, RED)).toBe(false);
+  });
+  it("returns false when no attackers", () => {
+    var board = [];
+    for (var c = 0; c < COLS; c++) board.push(new Array(ROWS).fill(EMPTY));
+    board[4][8] = R_GENERAL;
+    board[4][0] = B_GENERAL;
+    expect(isInCheck(board, RED)).toBe(false);
+    expect(isInCheck(board, BLACK)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #71.

Add check (将军) and checkmate (绝杀) detection with visual prompts to the Chinese Chess game. When a player's general is under attack, the game displays a prominent check message. When a player is checkmated, the game displays a checkmate message and ends the game.

## Problem

The Chinese Chess game had no visual indication when a player was in check or checkmate. Players had to manually track whether their general was under attack, which made the game confusing especially for new players. Additionally, checkmate was not correctly detected because moves that would leave one's own general in check were not filtered out.

## Solution

1. Added `isInCheck(board, color)` function to detect when a general is under attack by any opponent piece
2. Modified `getValidMoves()` to filter out moves that would leave one's own general in check (this was the key fix for correct checkmate detection)
3. Modified `endTurn()` to detect check/checkmate states after each move
4. Modified `renderGame()` and `updateMessage()` to display check/checkmate messages with dedicated CSS styles

## Changes

- `apps/board-game/chinese-chess/game.js`
  - Added `isInCheck()` function for check detection
  - Modified `getValidMoves()` to filter out illegal moves (leaving general in check)
  - Modified `endTurn()` to detect check/checkmate states
  - Modified `renderGame()` to display check/checkmate messages
  - Modified `updateMessage()` to support check/checkmate message types
  - Delay AI thinking by 1000ms when in check so message is visible
- `apps/board-game/chinese-chess/game.css`
  - Added dedicated CSS styles for check and checkmate messages with animations
- `apps/board-game/chinese-chess/game.test.js`
  - Added 7 new tests for `isInCheck` covering various piece attack patterns

## Verification

- `npm test` - 1760 tests pass
- `npm run lint` - no new errors
- CI checks pass

## Notes for reviewer

- The check detection uses raw piece movement functions (not `getValidMoves`) to avoid circular dependency
- Key fix: `getValidMoves()` now filters out moves that would leave own general in check, which is essential for correct checkmate detection
- Check messages use red gradient with pulse animation for high visibility
- Checkmate messages use orange gradient with stronger pulse animation
