### PR TITLE
Add strength-verified board-game AI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ tmp/
 
 # Vitest coverage output
 coverage/
+
+# AI shootout baseline snapshots
+.tmp-ai-baseline/

--- a/apps/board-game/gomoku/ai.js
+++ b/apps/board-game/gomoku/ai.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-var, no-unused-vars, prefer-arrow-callback */
+/* eslint-disable no-unused-vars, prefer-arrow-callback */
 (function (root, factory) {
   const api = factory();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
@@ -26,6 +26,60 @@
     const SCORE_HUMAN = [0, 200, 400, 2000, 10000];
 
     const SCORE_AI = [0, 220, 420, 2100, 20000];
+
+    // A completed five, used as a catastrophic penalty when a candidate move
+    // lets the opponent win on their next turn.
+    const FIVE_THREAT = 100000;
+
+    const SEARCH_CANDIDATES = 8;
+
+    // Best single-point threat the attacker can realize on their next move,
+    // scanning every win line once. Mixed lines (both players) contribute
+    // nothing. A line with four attacker stones means an immediate five.
+    function maxPointThreat(board, attacker) {
+      const defender = getOpponent(attacker);
+      let best = 0;
+      for (let lid = 0; lid < WIN_LINES.length; lid++) {
+        const line = WIN_LINES[lid];
+        let count = 0;
+        let blocked = false;
+        const empties = [];
+        for (let k = 0; k < line.length; k++) {
+          const val = board[line[k].y][line[k].x];
+          if (val === attacker) count++;
+          else if (val === defender) blocked = true;
+          else empties.push(line[k]);
+        }
+        if (blocked) continue;
+        if (count === 0) continue;
+        if (count === line.length - 1) return FIVE_THREAT;
+        for (const point of empties) {
+          const threat = SCORE_HUMAN[count];
+          if (threat > best) best = threat;
+        }
+      }
+      return best;
+    }
+
+    // Count how many distinct winning lines the attacker could complete on
+    // their next move. Two or more means a double threat (four + three, etc).
+    function openThreatCount(board, attacker) {
+      const defender = getOpponent(attacker);
+      let count = 0;
+      for (let lid = 0; lid < WIN_LINES.length; lid++) {
+        const line = WIN_LINES[lid];
+        let a = 0;
+        let blocked = false;
+        for (let k = 0; k < line.length; k++) {
+          const val = board[line[k].y][line[k].x];
+          if (val === attacker) a++;
+          else if (val === defender) blocked = true;
+        }
+        if (blocked) continue;
+        if (a >= 3) count++;
+      }
+      return count;
+    }
 
     function getBestAIMove(board, aiPlayer, difficulty) {
       const humanPlayer = getOpponent(aiPlayer);
@@ -121,7 +175,61 @@
         return { x: center, y: center };
       }
 
-      return { x: bestX, y: bestY };
+      // Completing our own five or blocking the opponent's five is forced;
+      // never second-guess it with the shallow search below.
+      if (scoreAI[bestX][bestY] >= SCORE_AI[4] || scoreHuman[bestX][bestY] >= SCORE_HUMAN[4]) {
+        return { x: bestX, y: bestY };
+      }
+      if (level === "normal") {
+        return { x: bestX, y: bestY };
+      }
+
+      // Hard/master: refine the top scoring candidates with a one-move
+      // lookahead. A candidate is devalued by the best threat the opponent
+      // gains on their reply, so moves that hand the opponent a four, an
+      // open three or a double threat lose to safer moves of similar value.
+      // Master additionally prefers creating its own open-four / double-three.
+      const threatFactor = level === "master" ? 1 : 0.9;
+      const candidates = [];
+      for (let y = 0; y < BOARD_SIZE; y++) {
+        for (let x = 0; x < BOARD_SIZE; x++) {
+          if (board[y][x] !== EMPTY) continue;
+          if (scoreAI[x][y] === 0 && scoreHuman[x][y] === 0) continue;
+          const center = Math.floor(BOARD_SIZE / 2);
+          const centerBonus =
+            level === "master" ? BOARD_SIZE - Math.abs(x - center) - Math.abs(y - center) : 0;
+          const s = scoreAI[x][y] * attackWeight + scoreHuman[x][y] + centerBonus;
+          candidates.push({ x: x, y: y, s: s });
+        }
+      }
+      candidates.sort((a, b) => b.s - a.s);
+      const top = candidates.slice(0, SEARCH_CANDIDATES);
+
+      let bestCandidate = top[0];
+      let bestAdjusted = -Infinity;
+      for (const candidate of top) {
+        const nextBoard = board.map((row) => row.slice());
+        nextBoard[candidate.y][candidate.x] = aiPlayer;
+        if (checkWinAt(nextBoard, candidate.x, candidate.y, aiPlayer)) {
+          return { x: candidate.x, y: candidate.y };
+        }
+        const oppThreat = maxPointThreat(nextBoard, humanPlayer);
+        const myThreat = maxPointThreat(nextBoard, aiPlayer);
+        // Prefer creating multiple open three-or-better lines (double threat).
+        const myDoubles = openThreatCount(nextBoard, aiPlayer);
+        const oppDoubles = openThreatCount(nextBoard, humanPlayer);
+        const adjusted =
+          candidate.s +
+          myThreat * 0.25 +
+          Math.max(0, myDoubles - 1) * 2500 * (level === "master" ? 1 : 0.8) -
+          oppThreat * threatFactor -
+          Math.max(0, oppDoubles - 1) * 3000;
+        if (adjusted > bestAdjusted) {
+          bestAdjusted = adjusted;
+          bestCandidate = candidate;
+        }
+      }
+      return { x: bestCandidate.x, y: bestCandidate.y };
     }
 
     return { SCORE_HUMAN, SCORE_AI, getBestAIMove };

--- a/apps/board-game/international-chess/ai.js
+++ b/apps/board-game/international-chess/ai.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-var, no-unused-vars, prefer-arrow-callback */
+/* eslint-disable no-unused-vars, prefer-arrow-callback */
 (function (root, factory) {
   const api = factory();
   if (typeof module !== "undefined" && module.exports) module.exports = api;
@@ -67,6 +67,8 @@
 
     const AI_DEPTH = 3;
 
+    const QUIESCENCE_MAX_PLY = 6;
+
     function getPositionValue(piece, c, r) {
       if (piece === W_PAWN) return PAWN_POS_WHITE[c][r];
       if (piece === B_PAWN) return PAWN_POS_BLACK[c][r];
@@ -90,17 +92,63 @@
       return aiScore - oppScore;
     }
 
+    // MVV-LVA: order captures by the value of the victim minus the value of
+    // the attacker so the cheapest winning captures are searched first and
+    // alpha-beta cuts arrive as early as possible.
+    function moveOrderScore(board, move) {
+      let score = 0;
+      if (move.promotion) score += 800;
+      const victim = board[move.toC][move.toR];
+      if (victim !== EMPTY) {
+        score += PIECE_VALUES[victim] * 10 - PIECE_VALUES[board[move.fromC][move.fromR]];
+      }
+      return score;
+    }
+
+    // Capture-only search at the horizon: resolves hanging-piece sequences so
+    // the static evaluation is only trusted in quiet positions.
+    function quiescence(board, alpha, beta, sideToMove, hasMoved, ply) {
+      const standPat = evaluateBoard(board, sideToMove);
+      if (standPat >= beta) return beta;
+      if (standPat > alpha) alpha = standPat;
+      if (ply >= QUIESCENCE_MAX_PLY) return alpha;
+
+      const moves = getAllMoves(board, sideToMove, hasMoved);
+      const captures = moves.filter((m) => board[m.toC][m.toR] !== EMPTY || m.promotion);
+      if (captures.length === 0) return alpha;
+
+      captures.sort((a, b) => moveOrderScore(board, b) - moveOrderScore(board, a));
+      for (const move of captures) {
+        const newBoard = applyMove(board, move);
+        const score = -quiescence(
+          newBoard,
+          -beta,
+          -alpha,
+          getOpponent(sideToMove),
+          hasMoved,
+          ply + 1
+        );
+        if (score >= beta) return beta;
+        if (score > alpha) alpha = score;
+      }
+      return alpha;
+    }
+
     function alphaBeta(board, depth, alpha, beta, aiColor, isAITurn, hasMoved) {
       const currentPlayer = isAITurn ? aiColor : getOpponent(aiColor);
       const gameOver = checkGameOver(board, currentPlayer, hasMoved);
       if (gameOver) {
-        if (gameOver.winner === aiColor) return 99999 + depth;
+        // Scores are relative to the side to move (negamax): winning on the
+        // move is good, being checkmated is bad, independent of aiColor.
+        if (gameOver.winner === currentPlayer) return 99999 + depth;
         if (gameOver.winner === null) return 0; // Draw
         return -99999 - depth;
       }
-      if (depth === 0) return evaluateBoard(board, aiColor);
+      if (depth === 0) return quiescence(board, alpha, beta, currentPlayer, hasMoved, 0);
 
       const moves = getAllMoves(board, currentPlayer, hasMoved);
+      moves.sort((a, b) => moveOrderScore(board, b) - moveOrderScore(board, a));
+
       let bestScore = -Infinity;
 
       for (const move of moves) {
@@ -129,25 +177,7 @@
       let bestScore = -Infinity;
 
       // Prioritize captures and promotions
-      moves.sort((a, b) => {
-        let scoreA;
-        if (a.promotion) {
-          scoreA = 800;
-        } else if (board[a.toC][a.toR] === EMPTY) {
-          scoreA = 0;
-        } else {
-          scoreA = PIECE_VALUES[board[a.toC][a.toR]];
-        }
-        let scoreB;
-        if (b.promotion) {
-          scoreB = 800;
-        } else if (board[b.toC][b.toR] === EMPTY) {
-          scoreB = 0;
-        } else {
-          scoreB = PIECE_VALUES[board[b.toC][b.toR]];
-        }
-        return scoreB - scoreA;
-      });
+      moves.sort((a, b) => moveOrderScore(board, b) - moveOrderScore(board, a));
 
       for (const move of moves) {
         const newBoard = applyMove(board, move);
@@ -155,7 +185,7 @@
           newBoard,
           searchDepth - 1,
           -Infinity,
-          Infinity,
+          -bestScore,
           aiColor,
           false,
           hasMoved
@@ -168,7 +198,16 @@
       return bestMove;
     }
 
-    return { AI_DEPTH, getPositionValue, evaluateBoard, alphaBeta, getBestAIMove };
+    return {
+      AI_DEPTH,
+      QUIESCENCE_MAX_PLY,
+      getPositionValue,
+      evaluateBoard,
+      moveOrderScore,
+      quiescence,
+      alphaBeta,
+      getBestAIMove,
+    };
   }
   return { createGameAI };
 });

--- a/apps/board-game/reversi/ai.js
+++ b/apps/board-game/reversi/ai.js
@@ -49,6 +49,132 @@
       handleRPSChoice,
     } = deps;
 
+    // Master-level search depth (plies). Depth 4 keeps the latency acceptable
+    // for an 8x8 board while avoiding most simple two-move traps.
+    const SEARCH_DEPTH = 4;
+
+    // Static positional weights: corners are decisive, the squares diagonally
+    // adjacent to corners (X-squares) are dangerous, edges are stable.
+    const POSITION_WEIGHTS = [
+      [120, -20, 20, 5, 5, 20, -20, 120],
+      [-20, -40, -5, -5, -5, -5, -40, -20],
+      [20, -5, 15, 3, 3, 15, -5, 20],
+      [5, -5, 3, 3, 3, 3, -5, 5],
+      [5, -5, 3, 3, 3, 3, -5, 5],
+      [20, -5, 15, 3, 3, 15, -5, 20],
+      [-20, -40, -5, -5, -5, -5, -40, -20],
+      [120, -20, 20, 5, 5, 20, -20, 120],
+    ];
+
+    const MOBILITY_WEIGHT = 8;
+
+    const DISC_WEIGHT = 2;
+
+    const WIN_SCORE = 100000;
+
+    function evaluateBoard(board, aiPlayer) {
+      const opponent = getOpponent(aiPlayer);
+      let positional = 0;
+      let myDiscs = 0;
+      let oppDiscs = 0;
+
+      for (let y = 0; y < BOARD_SIZE; y++) {
+        for (let x = 0; x < BOARD_SIZE; x++) {
+          const piece = board[y][x];
+          if (piece === aiPlayer) {
+            myDiscs++;
+            positional += POSITION_WEIGHTS[y][x];
+          } else if (piece === opponent) {
+            oppDiscs++;
+            positional -= POSITION_WEIGHTS[y][x];
+          }
+        }
+      }
+
+      // Mobility matters more than disc count until the board fills up.
+      const myMobility = getValidMoves(board, aiPlayer).length;
+      const oppMobility = getValidMoves(board, opponent).length;
+
+      return (
+        positional +
+        (myMobility - oppMobility) * MOBILITY_WEIGHT +
+        (myDiscs - oppDiscs) * DISC_WEIGHT
+      );
+    }
+
+    function finalScore(board, aiPlayer) {
+      const diff = countPieces(board);
+      const signedDiff = aiPlayer === PLAYER_BLACK ? diff : -diff;
+      if (signedDiff > 0) return WIN_SCORE + signedDiff;
+      if (signedDiff < 0) return -WIN_SCORE + signedDiff;
+      return 0;
+    }
+
+    function alphaBeta(board, player, depth, alpha, beta, aiPlayer) {
+      const moves = getValidMoves(board, player);
+
+      if (moves.length === 0) {
+        // Pass if the opponent can still move; otherwise the game is over.
+        const opponentMoves = getValidMoves(board, getOpponent(player));
+        if (opponentMoves.length === 0) return finalScore(board, aiPlayer);
+        return alphaBeta(board, getOpponent(player), depth, alpha, beta, aiPlayer);
+      }
+
+      if (depth === 0) return evaluateBoard(board, aiPlayer);
+
+      if (player === aiPlayer) {
+        let best = -Infinity;
+        for (const move of moves) {
+          const nextBoard = board.map((row) => row.slice());
+          makeMove(nextBoard, move.x, move.y, player);
+          const score = alphaBeta(nextBoard, getOpponent(player), depth - 1, alpha, beta, aiPlayer);
+          if (score > best) best = score;
+          if (best > alpha) alpha = best;
+          if (beta <= alpha) break;
+        }
+        return best;
+      }
+
+      let best = Infinity;
+      for (const move of moves) {
+        const nextBoard = board.map((row) => row.slice());
+        makeMove(nextBoard, move.x, move.y, player);
+        const score = alphaBeta(nextBoard, getOpponent(player), depth - 1, alpha, beta, aiPlayer);
+        if (score < best) best = score;
+        if (best < beta) beta = best;
+        if (beta <= alpha) break;
+      }
+      return best;
+    }
+
+    function searchBestMove(board, aiPlayer, depth) {
+      const moves = getValidMoves(board, aiPlayer);
+      // Corner moves are always safe to search first and often best.
+      const cornerRank = (m) =>
+        (m.x === 0 || m.x === BOARD_SIZE - 1) && (m.y === 0 || m.y === BOARD_SIZE - 1) ? 1 : 0;
+      const ordered = moves.slice().sort((a, b) => cornerRank(b) - cornerRank(a));
+
+      let bestMove = ordered[0];
+      let bestScore = -Infinity;
+      for (const move of ordered) {
+        const nextBoard = board.map((row) => row.slice());
+        makeMove(nextBoard, move.x, move.y, aiPlayer);
+        const score = alphaBeta(
+          nextBoard,
+          getOpponent(aiPlayer),
+          depth - 1,
+          -Infinity,
+          Infinity,
+          aiPlayer
+        );
+        if (score > bestScore) {
+          bestScore = score;
+          bestMove = move;
+        }
+      }
+      return bestMove;
+    }
+
     function getBestAIMove(board, aiPlayer, difficulty) {
       const validMoves = getValidMoves(board, aiPlayer);
       if (validMoves.length === 0) return null;
@@ -60,6 +186,11 @@
       if (level === "easy") {
         const move = validMoves[Math.floor(Math.random() * validMoves.length)];
         return { x: move.x, y: move.y };
+      }
+
+      if (level === "master") {
+        const best = searchBestMove(board, aiPlayer, SEARCH_DEPTH);
+        return { x: best.x, y: best.y };
       }
 
       let bestMove = validMoves[0];
@@ -74,11 +205,6 @@
             (move.y === 0 || move.y === BOARD_SIZE - 1);
           score += isCorner ? 100 : isEdge ? 8 : 0;
         }
-        if (level === "master") {
-          const nextBoard = board.map((row) => row.slice());
-          makeMove(nextBoard, move.x, move.y, aiPlayer);
-          score -= getValidMoves(nextBoard, getOpponent(aiPlayer)).length * 2;
-        }
         if (score > bestScore) {
           bestScore = score;
           bestMove = move;
@@ -88,7 +214,7 @@
       return { x: bestMove.x, y: bestMove.y };
     }
 
-    return { getBestAIMove };
+    return { SEARCH_DEPTH, evaluateBoard, alphaBeta, searchBestMove, getBestAIMove };
   }
   return { createGameAI };
 });

--- a/scripts/board-ai-shootout.mjs
+++ b/scripts/board-ai-shootout.mjs
@@ -1,0 +1,599 @@
+// Board-game AI shootout: quantify whether computer strength actually improved.
+// Mirrors scripts/ai-shootout.mjs (card games) for apps/board-game.
+//
+// Measurement standard
+// --------------------
+// 1) Difficulty scaling: master vs easy self-play. Master should score >= 65%
+//    (draws = 0.5). Otherwise difficulty levels are not meaningfully ordered.
+// 2) PR effectiveness: both current-branch master and baseline master play the
+//    SAME baseline-normal opponent (alternating colors). A real improvement is
+//    a strictly higher score than the baseline master against that fixed foe.
+// 3) Unit tests remain the legality/tactic gate; this harness is the strength gate.
+//
+// Usage:
+//   node scripts/board-ai-shootout.mjs --extract-baseline
+//   node scripts/board-ai-shootout.mjs --mode=both
+//   node scripts/board-ai-shootout.mjs --games=reversi,gomoku --matches=10 --mode=pr
+//
+// Modes: scale | pr | both (default both)
+
+import { createRequire } from "module";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+const boardRoot = path.join(root, "apps", "board-game");
+const baselineRoot = path.join(root, ".tmp-ai-baseline", "apps", "board-game");
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function random() {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function withSeed(seed, fn) {
+  const original = Math.random;
+  Math.random = mulberry32(seed);
+  try {
+    return fn();
+  } finally {
+    Math.random = original;
+  }
+}
+
+function clearModuleCache(dirPrefix) {
+  for (const key of Object.keys(require.cache)) {
+    if (key.startsWith(dirPrefix)) delete require.cache[key];
+  }
+}
+
+function loadGame(game, { baseline = false } = {}) {
+  const dir = baseline ? path.join(baselineRoot, game) : path.join(boardRoot, game);
+  if (!fs.existsSync(path.join(dir, "game.js"))) {
+    throw new Error(`Missing game module: ${dir}/game.js`);
+  }
+  clearModuleCache(dir);
+  return require(path.join(dir, "game.js"));
+}
+
+function extractBaseline() {
+  const games = fs
+    .readdirSync(boardRoot, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  const outRoot = path.join(root, ".tmp-ai-baseline");
+  fs.rmSync(outRoot, { recursive: true, force: true });
+  for (const game of games) {
+    const dest = path.join(outRoot, "apps", "board-game", game);
+    fs.mkdirSync(dest, { recursive: true });
+    for (const file of ["ai.js", "game.js"]) {
+      const content = execFileSync("git", ["show", `master:apps/board-game/${game}/${file}`], {
+        cwd: root,
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      fs.writeFileSync(path.join(dest, file), content);
+    }
+  }
+  const commonDest = path.join(outRoot, "apps", "common");
+  fs.mkdirSync(commonDest, { recursive: true });
+  fs.copyFileSync(
+    path.join(root, "apps", "common", "game-utils.js"),
+    path.join(commonDest, "game-utils.js")
+  );
+  console.log(`Baseline extracted for ${games.length} games into ${outRoot}`);
+}
+
+// Side roles: "first" = opening-to-move player, "second" = reply.
+// For chinese-checkers (3+ rotation) we still only track first vs second seats.
+
+function createSeat(game, mod, role) {
+  const g = mod;
+  const s = { role, board: null, player: null };
+
+  switch (game) {
+    case "reversi":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.PLAYER_BLACK;
+      s.passCount = 0;
+      s.opening = g.PLAYER_BLACK;
+      break;
+    case "gomoku":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.BLACK;
+      s.opening = g.BLACK;
+      break;
+    case "international-chess":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.WHITE;
+      s.hasMoved = new Set();
+      s.epTarget = null;
+      s.opening = g.WHITE;
+      break;
+    case "checkers":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.RED;
+      s.opening = g.RED;
+      break;
+    case "chinese-chess":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.RED;
+      s.opening = g.RED;
+      break;
+    case "dou-shou-qi":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.RED;
+      s.opening = g.RED;
+      break;
+    case "chinese-checkers": {
+      const st = g.createGameState("pvp", 2);
+      g.initGame(st);
+      s.board = st.board;
+      s.players = st.players;
+      s.turnIdx = 0;
+      s.opening = st.players[0];
+      break;
+    }
+    case "go":
+      s.board = g.createGameState("pvp").board;
+      s.player = g.BLACK;
+      s.ko = null;
+      s.capturesB = 0;
+      s.capturesW = 0;
+      s.passCount = 0;
+      s.opening = g.BLACK;
+      break;
+    case "shogi":
+      s.board = g.initializeBoard();
+      s.capturedPieces = { [g.SENTE]: [], [g.GOTE]: [] };
+      s.player = g.SENTE;
+      s.opening = g.SENTE;
+      break;
+    default:
+      throw new Error(`No init for ${game}`);
+  }
+  return s;
+}
+
+function currentSide(game, s) {
+  switch (game) {
+    case "chinese-checkers":
+      return s.players[s.turnIdx % s.players.length] === s.players[0] ? "first" : "second";
+    default:
+      return s.player === s.opening ? "first" : "second";
+  }
+}
+
+function stepState(game, current, baseline, s, side) {
+  // side: "first" | "second" — who is about to move
+  const mod = side === "first" ? current : baseline;
+  const g = current;
+
+  switch (game) {
+    case "reversi": {
+      if (g.isGameOver(s.board) || s.passCount >= 2) {
+        const w = g.getWinner(s.board);
+        return {
+          over: true,
+          winner: w === "draw" || w == null ? null : w === g.PLAYER_BLACK ? "first" : "second",
+        };
+      }
+      const move = mod.getBestAIMove(s.board, s.player, "master");
+      if (!move) {
+        s.passCount++;
+        s.player = g.getOpponent(s.player);
+        return null;
+      }
+      s.passCount = 0;
+      g.makeMove(s.board, move.x, move.y, s.player);
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "gomoku": {
+      if (s.last && g.checkWinAt(s.board, s.last.x, s.last.y, s.last.player)) {
+        return { over: true, winner: s.last.player === g.BLACK ? "first" : "second" };
+      }
+      if (g.checkDraw(s.board)) return { over: true, winner: null };
+      const move = mod.getBestAIMove(s.board, s.player, "master");
+      if (!move) return { over: true, winner: null };
+      s.board = g.makeMove(s.board, move.x, move.y, s.player);
+      s.last = { x: move.x, y: move.y, player: s.player };
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "international-chess": {
+      const over = g.checkGameOver(s.board, s.player, s.hasMoved, s.epTarget);
+      if (over)
+        return {
+          over: true,
+          winner: over.winner == null ? null : over.winner === g.WHITE ? "first" : "second",
+        };
+      const move = mod.getBestAIMove(s.board, s.player, s.hasMoved, "master");
+      if (!move) return { over: true, winner: null };
+      s.hasMoved.add(move.fromC + "," + move.fromR);
+      s.hasMoved.add(move.toC + "," + move.toR);
+      if (move.castling) {
+        const rookFromC = move.toC === 6 ? 7 : 0;
+        s.hasMoved.add(rookFromC + "," + move.toR);
+        s.hasMoved.add((move.toC === 6 ? 5 : 3) + "," + move.toR);
+      }
+      s.board = g.applyMove(s.board, move);
+      s.epTarget = move.doublePawn ? { c: move.toC, r: (move.fromR + move.toR) / 2 } : null;
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "checkers": {
+      const over = g.checkGameOver(s.board, s.player);
+      if (over)
+        return {
+          over: true,
+          winner: over.winner == null ? null : over.winner === g.RED ? "first" : "second",
+        };
+      const move = mod.getBestAIMove(s.board, s.player, "master");
+      if (!move) return { over: true, winner: null };
+      s.board = g.applyMove(s.board, move);
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "chinese-chess": {
+      const over = g.checkGameOver(s.board, s.player);
+      if (over)
+        return {
+          over: true,
+          winner: over.winner == null ? null : over.winner === g.RED ? "first" : "second",
+        };
+      const move = mod.getBestAIMove(s.board, s.player, "master");
+      if (!move) return { over: true, winner: null };
+      s.board = g.applyMove(s.board, move);
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "dou-shou-qi": {
+      const over = g.checkGameOver(s.board, s.player);
+      if (over)
+        return {
+          over: true,
+          winner: over.winner == null ? null : over.winner === g.RED ? "first" : "second",
+        };
+      const move = mod.getBestAIMove(s.board, s.player, "master");
+      if (!move) return { over: true, winner: null };
+      s.board = g.applyMoveForAI(s.board, move);
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "chinese-checkers": {
+      const winner = g.checkGameOver(s.board, s.players);
+      if (winner) return { over: true, winner: winner === s.players[0] ? "first" : "second" };
+      const player = s.players[s.turnIdx % s.players.length];
+      const move = mod.getBestAIMove(s.board, player, s.players, "master");
+      s.turnIdx++;
+      if (!move) {
+        const next = s.players[s.turnIdx % s.players.length];
+        if (!g.getLegalMoves(s.board, next).length && !g.getLegalMoves(s.board, player).length) {
+          return { over: true, winner: null };
+        }
+        return null;
+      }
+      s.board = g.makeMove(s.board, move.from, move.to);
+      return null;
+    }
+    case "go": {
+      if (s.passCount >= 2 || g.getLegalMoves(s.board, s.player, s.ko).length === 0) {
+        s.passCount++;
+        if (s.passCount >= 2) {
+          const score = g.calculateScore(s.board);
+          return { over: true, winner: score.black + g.KOMI > score.white ? "first" : "second" };
+        }
+        s.player = g.getOpponent(s.player);
+        return null;
+      }
+      const move = mod.getBestAIMove(s.board, s.player, s.ko, s.capturesB, s.capturesW, "master");
+      if (!move) {
+        s.passCount++;
+        s.player = g.getOpponent(s.player);
+        if (s.passCount >= 2) {
+          const score = g.calculateScore(s.board);
+          return { over: true, winner: score.black + g.KOMI > score.white ? "first" : "second" };
+        }
+        return null;
+      }
+      const result = g.playMove(s.board, move.x, move.y, s.player);
+      if (!result) {
+        s.passCount++;
+        s.player = g.getOpponent(s.player);
+        return null;
+      }
+      s.passCount = 0;
+      if (s.player === g.BLACK) s.capturesB += result.captures;
+      else s.capturesW += result.captures;
+      s.board = result.board;
+      s.ko = result.koPoint;
+      s.player = g.getOpponent(s.player);
+      return null;
+    }
+    case "shogi": {
+      const status = g.getGameStatus(s.board, s.player, s.capturedPieces);
+      if (status.gameOver || status.checkmate || status.stalemate) {
+        if (status.checkmate)
+          return { over: true, winner: s.player === g.SENTE ? "second" : "first" };
+        return { over: true, winner: null };
+      }
+      const move = mod.getBestAIMove(s.board, s.capturedPieces, s.player, 3, "master");
+      if (!move) return { over: true, winner: null };
+      const applied = g.applyMove(s.board, move, s.capturedPieces);
+      s.board = applied.board;
+      s.capturedPieces = applied.capturedPieces;
+      s.player = s.player === g.SENTE ? g.GOTE : g.SENTE;
+      return null;
+    }
+    default:
+      throw new Error(`No step for ${game}`);
+  }
+}
+
+function runPair({ label, games, maxSteps, makeState, firstMod, secondMod, current, baseline }) {
+  let aWins = 0;
+  let bWins = 0;
+  let draws = 0;
+  let aborted = 0;
+  const t0 = Date.now();
+
+  for (let i = 0; i < games; i++) {
+    // Alternate: even → first mover is A; odd → first mover is B.
+    const firstIsA = i % 2 === 0;
+    const seed = 10007 + i * 7919;
+    const outcome = withSeed(seed, () => {
+      const s = makeState();
+      for (let step = 0; step < maxSteps; step++) {
+        const side = currentSide(s.gameName ?? "", s);
+        // Determine who is moving: side is first|second in game terms
+        // Map: if firstIsA, game-first = A = firstMod; else game-first = B = secondMod
+        const firstGameMod = firstIsA ? firstMod : secondMod;
+        const secondGameMod = firstIsA ? secondMod : firstMod;
+        const result = stepState(s.gameName, firstGameMod, secondGameMod, s, side);
+        if (result && result.over) {
+          if (result.winner == null) return { winner: null };
+          if (result.winner === "first") return { winner: firstIsA ? "A" : "B" };
+          return { winner: firstIsA ? "B" : "A" };
+        }
+      }
+      return { winner: null, aborted: true };
+    });
+    if (outcome.winner === "A") aWins++;
+    else if (outcome.winner === "B") bWins++;
+    else draws++;
+    if (outcome.aborted) aborted++;
+  }
+
+  const ms = Date.now() - t0;
+  const aScore = (aWins + draws * 0.5) / games;
+  console.log(
+    `${label}: A ${aWins} - B ${bWins} (draws ${draws}) over ${games} | A score ${(aScore * 100).toFixed(1)}% | ${ms}ms${aborted ? ` | aborted ${aborted}` : ""}`
+  );
+  return { label, aWins, bWins, draws, aborted, aScore, ms };
+}
+
+function makeFactory(game, current, baseline) {
+  return () => {
+    const s = createSeat(game, current, "first");
+    s.gameName = game;
+    return s;
+  };
+}
+
+// Wrap getBestAIMove to force a difficulty level (for scale mode).
+function withForcedLevel(mod, level) {
+  // We cannot rebind module exports easily; instead we rely on passing
+  // difficulty as the last argument. stepState already passes "master".
+  // For scale mode we need per-side difficulty — use a Proxy on the module.
+  return new Proxy(mod, {
+    get(target, prop) {
+      if (prop === "getBestAIMove") {
+        const original = target.getBestAIMove;
+        return (...args) => {
+          // Replace trailing difficulty if present, else append.
+          if (typeof args[args.length - 1] === "string") {
+            args[args.length - 1] = level;
+            return original(...args);
+          }
+          return original(...args, level);
+        };
+      }
+      return target[prop];
+    },
+  });
+}
+
+const GAME_META = {
+  reversi: { maxSteps: 120, defaultMatches: 12 },
+  gomoku: { maxSteps: 260, defaultMatches: 12 },
+  "international-chess": { maxSteps: 180, defaultMatches: 6 },
+  checkers: { maxSteps: 180, defaultMatches: 8 },
+  "chinese-chess": { maxSteps: 160, defaultMatches: 4 },
+  "dou-shou-qi": { maxSteps: 160, defaultMatches: 4 },
+  "chinese-checkers": { maxSteps: 280, defaultMatches: 6 },
+  go: { maxSteps: 70, defaultMatches: 3 },
+  shogi: { maxSteps: 140, defaultMatches: 3 },
+};
+
+function runPairAgainst({ game, label, matches, maxSteps, current, trialMod, foeMod }) {
+  // trialMod always plays as A; foeMod as B. Sides alternate which color
+  // moves first, but A/B stay fixed so scores are comparable across trials.
+  const s0 = createSeat(game, current, "first");
+  s0.gameName = game;
+  let aWins = 0;
+  let bWins = 0;
+  let draws = 0;
+  let aborted = 0;
+  const t0 = Date.now();
+  for (let i = 0; i < matches; i++) {
+    const firstIsA = i % 2 === 0;
+    const seed = 10007 + i * 7919;
+    const outcome = withSeed(seed, () => {
+      const s = createSeat(game, current, "first");
+      s.gameName = game;
+      for (let step = 0; step < maxSteps; step++) {
+        const side = currentSide(game, s);
+        const firstGameMod = firstIsA ? trialMod : foeMod;
+        const secondGameMod = firstIsA ? foeMod : trialMod;
+        const result = stepState(game, firstGameMod, secondGameMod, s, side);
+        if (result && result.over) {
+          if (result.winner == null) return { winner: null };
+          if (result.winner === "first") return { winner: firstIsA ? "A" : "B" };
+          return { winner: firstIsA ? "B" : "A" };
+        }
+      }
+      return { winner: null, aborted: true };
+    });
+    if (outcome.winner === "A") aWins++;
+    else if (outcome.winner === "B") bWins++;
+    else draws++;
+    if (outcome.aborted) aborted++;
+  }
+  const ms = Date.now() - t0;
+  const aScore = (aWins + draws * 0.5) / matches;
+  console.log(
+    `${label}: A ${aWins} - B ${bWins} (draws ${draws}) over ${matches} | A score ${(aScore * 100).toFixed(1)}% | ${ms}ms${aborted ? ` | aborted ${aborted}` : ""}`
+  );
+  void s0;
+  return { label, aWins, bWins, draws, aborted, aScore, ms };
+}
+
+function runSuite({ games, mode, matchesOverride }) {
+  const results = [];
+  for (const game of games) {
+    const meta = GAME_META[game];
+    const current = loadGame(game, { baseline: false });
+    const matches = matchesOverride || meta.defaultMatches;
+
+    if (mode === "scale") {
+      const result = runPair({
+        label: `${game} [master vs easy]`,
+        games: matches,
+        maxSteps: meta.maxSteps,
+        makeState: makeFactory(game, current, current),
+        firstMod: withForcedLevel(current, "master"),
+        secondMod: withForcedLevel(current, "easy"),
+        current,
+        baseline: null,
+      });
+      results.push({ game, mode: "scale", ...result });
+      continue;
+    }
+
+    // PR mode: fixed baseline-easy opponent.
+    const baseline = loadGame(game, { baseline: true });
+    const foe = withForcedLevel(baseline, "normal");
+    const newScore = runPairAgainst({
+      game,
+      label: `${game} [new master vs baseline normal]`,
+      matches,
+      maxSteps: meta.maxSteps,
+      current,
+      trialMod: withForcedLevel(current, "master"),
+      foeMod: foe,
+    });
+    const oldScore = runPairAgainst({
+      game,
+      label: `${game} [base master vs baseline normal]`,
+      matches,
+      maxSteps: meta.maxSteps,
+      current,
+      trialMod: withForcedLevel(baseline, "master"),
+      foeMod: withForcedLevel(baseline, "normal"),
+    });
+    results.push({
+      game,
+      mode: "pr",
+      label: `${game} [new vs base vs fixed foe]`,
+      aScore: newScore.aScore,
+      baseScore: oldScore.aScore,
+      aWins: newScore.aWins,
+      bWins: newScore.bWins,
+      draws: newScore.draws,
+      aborted: newScore.aborted,
+      ms: newScore.ms + oldScore.ms,
+    });
+  }
+  return results;
+}
+
+function parseArgs(argv) {
+  const args = { mode: "both", games: null, matches: null, extractBaseline: false, help: false };
+  for (const raw of argv) {
+    if (raw === "--extract-baseline") args.extractBaseline = true;
+    else if (raw.startsWith("--mode=")) args.mode = raw.slice(7);
+    else if (raw.startsWith("--games=")) args.games = raw.slice(8).split(",").filter(Boolean);
+    else if (raw.startsWith("--matches=")) args.matches = Number(raw.slice(10));
+    else if (raw === "--help" || raw === "-h") args.help = true;
+  }
+  return args;
+}
+
+function summarize(results) {
+  console.log("\n=== Summary ===");
+  for (const r of results) {
+    if (r.mode === "scale") {
+      const status = r.aScore >= 0.65 ? "PASS" : r.aScore < 0.45 ? "FAIL" : "WEAK";
+      console.log(
+        `  scale ${r.game.padEnd(22)} master score=${(r.aScore * 100).toFixed(1)}%  ${status}`
+      );
+      continue;
+    }
+    const delta = r.aScore - (r.baseScore ?? 0.5);
+    const status = delta > 0.05 ? "GAIN" : delta < -0.05 ? "LOSS" : "FLAT";
+    console.log(
+      `  pr    ${r.game.padEnd(22)} new=${(r.aScore * 100).toFixed(1)}% base=${((r.baseScore ?? 0) * 100).toFixed(1)}% Δ=${(delta * 100).toFixed(1)}pp  ${status}`
+    );
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      `Usage: node scripts/board-ai-shootout.mjs [--mode=scale|pr|both] [--games=a,b] [--matches=N] [--extract-baseline]`
+    );
+    return;
+  }
+  if (args.extractBaseline) extractBaseline();
+
+  const allGames = Object.keys(GAME_META);
+  const games = args.games && args.games.length ? args.games : allGames;
+  for (const g of games) {
+    if (!GAME_META[g]) {
+      console.error(`Unknown game: ${g}. Known: ${allGames.join(", ")}`);
+      process.exit(1);
+    }
+  }
+
+  const results = [];
+  if (args.mode === "scale" || args.mode === "both") {
+    console.log("\n=== Difficulty scaling: master vs easy ===");
+    results.push(...runSuite({ games, mode: "scale", matchesOverride: args.matches }));
+  }
+  if (args.mode === "pr" || args.mode === "both") {
+    if (!fs.existsSync(baselineRoot)) {
+      console.log("\nBaseline missing — run --extract-baseline first. Skipping PR suite.");
+    } else {
+      console.log("\n=== PR effectiveness: new master vs baseline master ===");
+      results.push(...runSuite({ games, mode: "pr", matchesOverride: args.matches }));
+    }
+  }
+  if (results.length) summarize(results);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## 概述

引入可复现的棋类 AI 战力测评机制，并仅保留经测评确认有真实提升的优化。

## 提交历史

| # | Commit | 内容 | 测评结论 |
|---|--------|------|----------|
| 1 | `2a76dc4` | `scripts/board-ai-shootout.mjs` 棋类 AI 战力 shootout | 机制本体 |
| 2 | `bfaf30c` | reversi：master 升级为 4 层 alpha-beta | vs baseline-normal **+100pp**（100% vs 0%） |
| 3 | `fc3e6b4` | gomoku：hard/master 双威胁评分 | vs baseline-normal **+50pp**（100% vs 50%） |
| 4 | `02ad988` | international-chess：修复 negamax 符号 + quiescence | normal 可正确吃白送后（基线不能）；hard 首步约 **3×** 更快 |

## 衡量标准

1. **难度缩放**：master vs easy 自对弈，master 得分 ≥ 65% → PASS  
2. **PR 收益**：当前 master 与 master 基线对**同一 baseline-normal**（轮换先手）比较；Δ > +5pp → GAIN  
3. 搜索较重的对局另用 short hard 局 + 战术位（如 free queen）作辅助信号  
4. 单元测试仍为合法性门禁

**复现：**
```bash
node scripts/board-ai-shootout.mjs --extract-baseline
node scripts/board-ai-shootout.mjs --mode=both --games=reversi,gomoku
```

## 验证

- 全量 `npm test`：34 files / **1849** tests 通过  
- `npm run lint`：**0 errors**  
- 未改动 README / sitemap / sw.js / Tauri 配置